### PR TITLE
Fix: handle missing assemblyArguments by normalizing to empty string

### DIFF
--- a/Execution-BOF/execute-assembly/inlineExecute-Assembly.c
+++ b/Execution-BOF/execute-assembly/inlineExecute-Assembly.c
@@ -421,6 +421,11 @@ void go(IN PCHAR buffer, IN ULONG blength)
     size_t assemblyByteLen = 0;
     char* assemblyBytes = BeaconDataExtract(&parser, &assemblyByteLen);
     char* assemblyArguments = BeaconDataExtract(&parser, NULL);
+	if (assemblyArguments == NULL) {
+        // no STRING arg supplied will use empty string
+        static char emptyArgs[] = "";
+        assemblyArguments = emptyArgs;
+    }
 
 	//BeaconPrintf(CALLBACK_OUTPUT, "[+] assemblyByteLen:   %d\n", assemblyByteLen);
 	//BeaconPrintf(CALLBACK_OUTPUT, "[+] assemblyArguments: %s\n", assemblyArguments);

--- a/Execution-BOF/execution_beacon.json
+++ b/Execution-BOF/execution_beacon.json
@@ -11,7 +11,7 @@
       "example": "execute-assembly /opt/windows/Seatbelt.exe -group=user",
       "args": [
             "FILE <path>",
-            "STRING <params>"
+            "STRING [params]"
       ],
       "exec": "execute bof $EXT_DIR()/_bin/execute-assembly.$ARCH().o $PACK_BOF(BYTES {path}, CSTR {params})"
     }


### PR DESCRIPTION
The execute-assembly bof does not have support for none arguments currently, and when using none arguments in the json config it crashes the agent. I have applied a fix for this. 