### PR TITLE
Conditional redirect_std_out_err_for_mingw for UCRT

### DIFF
--- a/Execution-BOF/No-Consolation/source/console.c
+++ b/Execution-BOF/No-Consolation/source/console.c
@@ -65,6 +65,11 @@ BOOL allocate_console(
 BOOL redirect_std_out_err_for_mingw(
     IN PLOADED_PE_INFO peinfo)
 {
+#ifdef _UCRT
+    (void)peinfo;
+    return TRUE;
+#else
+
     FILE* file = NULL;
 
     DPRINT("redirect_std_out_err_for_mingw");
@@ -155,6 +160,7 @@ BOOL redirect_std_out_err_for_mingw(
     }
 
     return TRUE;
+#endif
 }
 
 /*


### PR DESCRIPTION
This fix Execution-BOF/No-Consolation/source/entry.c compilation on Arch Linux

In Debian, MinGW‑w64 defaults to linking against the classic CRT `msvcrt.dll`, which provides legacy exports like `_open_osfhandle`/`__iob_func` and a writable `FILE` struct layout. On Arch Linux we are building with the UCRT toolchain `ucrtbase.dll`, which omits those symbols. By wrapping the MinGW‑specific redirection code with `#ifdef _UCRT`, we can skip any code that depends on the old CRT internals when targeting UCRT. That conditional compilation ensures the same source compiles cleanly under both CRT models

Before:
```
creating _bin
In file included from source/entry.c:6:
source/console.c: In function 'redirect_std_out_err_for_mingw':
source/console.c:106:13: error: 'FILE' {aka 'struct _iobuf'} has no member named '_file'
  106 |     if (file->_file == 1)
      |             ^~
source/console.c:124:13: error: 'FILE' {aka 'struct _iobuf'} has no member named '_flag'
  124 |         file->_flag = _IOWRT | _IONBF;
      |             ^~
source/console.c:124:23: error: '_IOWRT' undeclared (first use in this function)
  124 |         file->_flag = _IOWRT | _IONBF;
      |                       ^~~~~~
source/console.c:124:23: note: each undeclared identifier is reported only once for each function it appears in
source/console.c:125:13: error: 'FILE' {aka 'struct _iobuf'} has no member named '_file'
  125 |         file->_file = peinfo->Handles->fo_msvc;
      |             ^~
source/console.c:133:13: error: 'FILE' {aka 'struct _iobuf'} has no member named '_file'
  133 |     if (file->_file == 2)
      |             ^~
source/console.c:151:13: error: 'FILE' {aka 'struct _iobuf'} has no member named '_flag'
  151 |         file->_flag = _IOWRT | _IONBF;
      |             ^~
source/console.c:152:13: error: 'FILE' {aka 'struct _iobuf'} has no member named '_file'
  152 |         file->_file = peinfo->Handles->fo_msvc;
      |             ^~
[!] NoConsolation x64
In file included from source/entry.c:6:
source/console.c: In function 'redirect_std_out_err_for_mingw':
source/console.c:106:13: error: 'FILE' {aka 'struct _iobuf'} has no member named '_file'
  106 |     if (file->_file == 1)
      |             ^~
source/console.c:124:13: error: 'FILE' {aka 'struct _iobuf'} has no member named '_flag'
  124 |         file->_flag = _IOWRT | _IONBF;
      |             ^~
source/console.c:124:23: error: '_IOWRT' undeclared (first use in this function)
  124 |         file->_flag = _IOWRT | _IONBF;
      |                       ^~~~~~
source/console.c:124:23: note: each undeclared identifier is reported only once for each function it appears in
source/console.c:125:13: error: 'FILE' {aka 'struct _iobuf'} has no member named '_file'
  125 |         file->_file = peinfo->Handles->fo_msvc;
      |             ^~
source/console.c:133:13: error: 'FILE' {aka 'struct _iobuf'} has no member named '_file'
  133 |     if (file->_file == 2)
      |             ^~
source/console.c:151:13: error: 'FILE' {aka 'struct _iobuf'} has no member named '_flag'
  151 |         file->_flag = _IOWRT | _IONBF;
      |             ^~
source/console.c:152:13: error: 'FILE' {aka 'struct _iobuf'} has no member named '_file'
  152 |         file->_file = peinfo->Handles->fo_msvc;
      |             ^~
[!] NoConsolation x86
```

After:
```
creating _bin
[+] NoConsolation x64
[+] NoConsolation x86
```