### PR TITLE
Fix for x86_64-w64-mingw32-gcc 15

### DIFF
--- a/AD-BOF/Kerbeus-BOF/_include/kerb_struct.h
+++ b/AD-BOF/Kerbeus-BOF/_include/kerb_struct.h
@@ -2,9 +2,12 @@
 
 typedef unsigned int uint;
 typedef unsigned char byte;
+
+#if !(__GNUC__ >= 15)
 typedef int bool;
 #define true 1
 #define false 0
+#endif
 
 enum KRB_KEY_USAGE {
 	KRB_KEY_USAGE_AS_REQ_PA_ENC_TIMESTAMP = 1,


### PR DESCRIPTION
Kerberos BOFs weren't compiling on x86_64-w64-mingw32-gcc 15.x.x due int bool definition. This commit do a conditional definition if compiler is 15.x.x to support 15.x.x version, ensuring only GCC 15+ skips the typedef and macros while older versions keep them

Before:
```
_bin directory exists
[+] ldapsearch
_bin exists
In file included from hash/../_include/functions.c:4,
                 from hash/hash.c:1:
hash/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
hash/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] hash
In file included from klist/../_include/functions.c:4,
                 from klist/klist.c:1:
klist/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
klist/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] klist
In file included from klist/../_include/functions.c:4,
                 from klist/klist.c:1:
klist/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
klist/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] triage
In file included from klist/../_include/functions.c:4,
                 from klist/klist.c:1:
klist/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
klist/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] dump
In file included from describe/../_include/functions.c:4,
                 from describe/../_include/asn_convert.c:2,
                 from describe/../_include/asn_decode.c:1,
                 from describe/describe.c:1:
describe/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
describe/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] describe
In file included from tgtdeleg/../_include/functions.c:4,
                 from tgtdeleg/../_include/asn_convert.c:2,
                 from tgtdeleg/../_include/asn_encode.c:1,
                 from tgtdeleg/tgtdeleg.c:1:
tgtdeleg/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
tgtdeleg/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] tgtdeleg
In file included from ptt/../_include/functions.c:4,
                 from ptt/ptt.c:1:
ptt/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
ptt/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] ptt
In file included from purge/../_include/functions.c:4,
                 from purge/purge.c:1:
purge/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
purge/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] purge
In file included from asktgt/../_include/functions.c:4,
                 from asktgt/../_include/asn_convert.c:2,
                 from asktgt/../_include/asn_decode.c:1,
                 from asktgt/asktgt.c:1:
asktgt/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
asktgt/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] asktgt
In file included from asktgs/../_include/functions.c:4,
                 from asktgs/../_include/asn_convert.c:2,
                 from asktgs/../_include/asn_decode.c:1,
                 from asktgs/asktgs.c:1:
asktgs/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
asktgs/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] asktgs
In file included from renew/../_include/functions.c:4,
                 from renew/../_include/asn_convert.c:2,
                 from renew/../_include/asn_encode.c:1,
                 from renew/renew.c:1:
renew/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
renew/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] renew
In file included from changepw/../_include/functions.c:4,
                 from changepw/../_include/asn_convert.c:2,
                 from changepw/../_include/asn_decode.c:1,
                 from changepw/changepw.c:1:
changepw/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
changepw/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] changepw
In file included from ./_include/functions.c:4,
                 from asreproasting/asreproasting.c:1:
./_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
./_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] asreproasting
In file included from ./_include/functions.c:4,
                 from ./_include/asn_convert.c:2,
                 from ./_include/asn_encode.c:1,
                 from kerberoasting/kerberoasting.c:1:
./_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
./_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] kerberoasting
In file included from s4u/../_include/functions.c:4,
                 from s4u/../_include/asn_convert.c:2,
                 from s4u/../_include/asn_encode.c:1,
                 from s4u/s4u.c:1:
s4u/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
s4u/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] s4u
In file included from s4u/../_include/functions.c:4,
                 from s4u/../_include/asn_convert.c:2,
                 from s4u/../_include/asn_encode.c:1,
                 from s4u/cross_s4u.c:1:
s4u/../_include/kerb_struct.h:5:13: error: 'bool' cannot be defined via 'typedef'
    5 | typedef int bool;
      |             ^~~~
s4u/../_include/kerb_struct.h:5:13: note: 'bool' is a keyword with '-std=c23' onwards
[!] cross_s4u
cp: cannot stat 'Kerbeus-BOF/_bin/*.o': No such file or directory
make: *** [Makefile:7: bof] Error 1
```

Afer:
```
creating _bin directory
[+] ldapsearch
creating _bin
[+] hash
[+] klist
[+] triage
[+] dump
[+] describe
[+] tgtdeleg
[+] ptt
[+] purge
[+] asktgt
[+] asktgs
[+] renew
[+] changepw
[+] asreproasting
[+] kerberoasting
[+] s4u
[+] cross_s4u
```

Tested on Ubuntu 23.04 Lunar and Arch Linux (Latest update)