### PR TITLE
fix hasOwnProperty type error

### DIFF
--- a/Creds-BOF/cookie-monster/cookie-monster.axs
+++ b/Creds-BOF/cookie-monster/cookie-monster.axs
@@ -43,9 +43,9 @@ cmd_cookie_monster.setPreHook(function (id, cmdline, parsed_json, ...parsed_line
     if(parsed_json["--edgeCookiePID"]) { edgeCookiePID = 1; }
     if(parsed_json["--edgeLoginDataPID"]) { edgeLoginDataPID = 1; }
 
-    if(parsed_json.hasOwnProperty("folder")) { copyFile = parsed_json["folder"]; }
+    if("folder" in parsed_json) { copyFile = parsed_json["folder"]; }
 
-    if(parsed_json.hasOwnProperty("local_state_path")) {
+    if("local_state_path" in parsed_json) {
         path = parsed_json["local_state_path"];
         system = 1;
     }

--- a/Creds-BOF/nanodump/nanodump.axs
+++ b/Creds-BOF/nanodump/nanodump.axs
@@ -53,18 +53,18 @@ cmd_nanodump.setPreHook(function (id, cmdline, parsed_json, ...parsed_lines)
     if(parsed_json["-sd"]) { use_seclogon_duplicate = 1; }
     if(parsed_json["-sc"]) { spoof_callstack = 1; }
 
-    if(parsed_json.hasOwnProperty("PID")) {
+    if("PID" in parsed_json) {
         pid = parsed_json["PID"];
     }
-    if(parsed_json.hasOwnProperty("SPE_DUMP_FOLDER")) {
+    if("SPE_DUMP_FOLDER" in parsed_json) {
         silent_process_exit = parsed_json["SPE_DUMP_FOLDER"];
         use_silent_process_exit = 1;
     }
-    if(parsed_json.hasOwnProperty("SLR_BIN_PATH")) {
+    if("SLR_BIN_PATH" in parsed_json) {
         seclogon_leak_remote_binary = parsed_json["SLR_BIN_PATH"];
         use_seclogon_leak_remote = 1;
     }
-    if(parsed_json.hasOwnProperty("DUMP_PATH")) {
+    if("DUMP_PATH" in parsed_json) {
         dump_path = parsed_json["DUMP_PATH"];
         write_file = 1;
     }
@@ -219,8 +219,8 @@ cmd_nanodump_ssp.setPreHook(function (id, cmdline, parsed_json, ...parsed_lines)
     if ( !(/^[A-Za-z]:\\.*/.test(dump_path)) ) { throw new Error("You need to provide the full path: " + dump_path); }
 
     if(parsed_json["--valid"]) { use_valid_sig = 1; }
-    if(parsed_json.hasOwnProperty("WRITE_DLL")) { write_dll_path = parsed_json["WRITE_DLL"]; }
-    if(parsed_json.hasOwnProperty("LOAD_DLL")) { load_dll_path = parsed_json["LOAD_DLL"]; }
+    if("WRITE_DLL" in parsed_json) { write_dll_path = parsed_json["WRITE_DLL"]; }
+    if("LOAD_DLL" in parsed_json) { load_dll_path = parsed_json["LOAD_DLL"]; }
 
     if( load_dll_path.length && write_dll_path.length ) { throw new Error("The options --write-dll and --load-dll cannot be used together"); }
     if( load_dll_path.length && !(/^[A-Za-z]:\\.*/.test(load_dll_path)) ) { throw new Error("You need to provide the full path: " + load_dll_path); }

--- a/Elevation-BOF/elevate.axs
+++ b/Elevation-BOF/elevate.axs
@@ -55,7 +55,7 @@ cmd_dcom_potato.setPreHook(function (id, cmdline, parsed_json, ...parsed_lines) 
     let run_program = "";
 
     if(parsed_json["--token"]) { use_token = 1; }
-    if(parsed_json.hasOwnProperty("program")) { run_program = parsed_json["program"]; }
+    if("program" in parsed_json) { run_program = parsed_json["program"]; }
 
     if( (use_token && run_program.length) || (!use_token && run_program.length == 0) ) { throw new Error("Use only --token or --run"); }
 

--- a/Execution-BOF/No-Consolation/no_consolation.axs
+++ b/Execution-BOF/No-Consolation/no_consolation.axs
@@ -65,14 +65,14 @@ cmd_no_consolation.setPreHook(function (id, cmdline, parsed_json, ...parsed_line
     if(parsed_json["--dont-unload"]) { dont_unload = 1; }
     if(parsed_json["-lad"]) { load_all_deps = 1; }
 
-    if(parsed_json.hasOwnProperty("EXPORT_NAME")) { timeout = parsed_json["EXPORT_NAME"]; }
-    if(parsed_json.hasOwnProperty("FL_DLLS")) { free_libs = parsed_json["FL_DLLS"]; }
-    if(parsed_json.hasOwnProperty("PE_NAME")) { unload_pe = parsed_json["PE_NAME"]; }
-    if(parsed_json.hasOwnProperty("LADB_DLLS")) { load_all_deps_but = parsed_json["LADB_DLLS"]; }
-    if(parsed_json.hasOwnProperty("LD_DLLS")) { load_deps = parsed_json["LD_DLLS"]; }
-    if(parsed_json.hasOwnProperty("PATHS")) { search_paths = parsed_json["PATHS"]; }
+    if("EXPORT_NAME" in parsed_json) { timeout = parsed_json["EXPORT_NAME"]; }
+    if("FL_DLLS" in parsed_json) { free_libs = parsed_json["FL_DLLS"]; }
+    if("PE_NAME" in parsed_json) { unload_pe = parsed_json["PE_NAME"]; }
+    if("LADB_DLLS" in parsed_json) { load_all_deps_but = parsed_json["LADB_DLLS"]; }
+    if("LD_DLLS" in parsed_json) { load_deps = parsed_json["LD_DLLS"]; }
+    if("PATHS" in parsed_json) { search_paths = parsed_json["PATHS"]; }
 
-    if(parsed_json.hasOwnProperty("NUM_SECONDS")) {
+    if("NUM_SECONDS" in parsed_json) {
         timeout = parsed_json["NUM_SECONDS"];
         timeout_set = 1;
     }
@@ -115,7 +115,7 @@ cmd_no_consolation.setPreHook(function (id, cmdline, parsed_json, ...parsed_line
 
     if (path_set || name_set) {
         pecmdline = pename;
-        if(parsed_json.hasOwnProperty("args")) {
+        if("args" in parsed_json) {
             pecmdline += " " + parsed_json["args"];
         }
     }


### PR DESCRIPTION
In some environments `parsed_json` is  not returning as a standard js object, causing `Error: Property 'hasOwnProperty' of object TypeError: Type error is not a function`

Switched to using `"property" in parsed_json` instead of `parsed_json.hasOwnProperty("property")`