### PR TITLE
Add missing typedef

### DIFF
--- a/Creds-BOF/cookie-monster/cookie-monster-bof.c
+++ b/Creds-BOF/cookie-monster/cookie-monster-bof.c
@@ -6,6 +6,10 @@
 #include "cookie-monster-bof.h"
 #include "adaptix.h"
 
+// Add missing typedef
+typedef HRESULT (WINAPI *PFN_SHGetFolderPathA)(HWND hwndOwner, int nFolder, HANDLE hToken, DWORD dwFlags, LPSTR pszPath);
+typedef BOOL (WINAPI *PFN_PathAppendA)(LPSTR pszPath, LPCSTR pMore);
+
 // Function declarations
 BOOL download_file(IN LPCSTR fileName, IN char fileData[], IN ULONG32 fileLength);
 BOOL GetBrowserFile(DWORD PID, CHAR *browserFile, CHAR *downloadFileName, CHAR * folderPath);


### PR DESCRIPTION
An error was detected during compilation: 

```
=====>>  Creds-BOF
creating _bin directory
[+] askcreds
[+] autologon
[+] credman
[+] get-netntlm
[+] hashdump
cookie-monster/cookie-monster-bof.c: In function ‘GetFileContent’:
cookie-monster/cookie-monster-bof.c:74:24: error: unknown type name ‘PFN_SHGetFolderPathA’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                        ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:24: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                        ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: error: ‘PFN_SHGetFolderPathA’ undeclared (first use in this function); did you mean ‘SHGetFolderPath’?
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: note: each undeclared identifier is reported only once for each function it appears in
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:85: error: expected ‘,’ or ‘;’ before ‘Resolver’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                                     ^~~~~~~~
cookie-monster/cookie-monster-bof.c:74:85: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                                     ^~~~~~~~
cookie-monster/cookie-monster-bof.c:75:5: error: unknown type name ‘PFN_PathAppendA’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:5: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:35: error: ‘PFN_PathAppendA’ undeclared (first use in this function); did you mean ‘PathAppend’?
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                   ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:35: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                   ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:51: error: expected ‘,’ or ‘;’ before ‘Resolver’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                                   ^~~~~~~~
cookie-monster/cookie-monster-bof.c:75:51: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                                   ^~~~~~~~
cookie-monster/cookie-monster-bof.c:107:9: error: called object ‘SHGetFolderPath’ is not a function or function pointer
  107 |         SHGetFolderPath(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, appdata);
      |         ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:45: note: declared here
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                             ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:45: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                             ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:108:9: error: called object ‘PathAppend’ is not a function or function pointer
  108 |         PathAppend(appdata, path);
      |         ^~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:21: note: declared here
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                     ^~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:21: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                     ^~~~~~~~~~
cookie-monster/cookie-monster-bof.c: In function ‘GetMasterKey’:
cookie-monster/cookie-monster-bof.c:74:24: error: unknown type name ‘PFN_SHGetFolderPathA’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                        ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:24: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                        ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: error: ‘PFN_SHGetFolderPathA’ undeclared (first use in this function); did you mean ‘SHGetFolderPath’?
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:85: error: expected ‘,’ or ‘;’ before ‘Resolver’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                                     ^~~~~~~~
cookie-monster/cookie-monster-bof.c:74:85: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                                     ^~~~~~~~
cookie-monster/cookie-monster-bof.c:75:5: error: unknown type name ‘PFN_PathAppendA’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:5: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:35: error: ‘PFN_PathAppendA’ undeclared (first use in this function); did you mean ‘PathAppend’?
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                   ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:35: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                   ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:51: error: expected ‘,’ or ‘;’ before ‘Resolver’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                                   ^~~~~~~~
cookie-monster/cookie-monster-bof.c:75:51: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                                   ^~~~~~~~
cookie-monster/cookie-monster-bof.c: In function ‘GetFirefoxFile’:
cookie-monster/cookie-monster-bof.c:74:24: error: unknown type name ‘PFN_SHGetFolderPathA’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                        ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:24: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                        ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: error: ‘PFN_SHGetFolderPathA’ undeclared (first use in this function); did you mean ‘SHGetFolderPath’?
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:85: error: expected ‘,’ or ‘;’ before ‘Resolver’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                                     ^~~~~~~~
cookie-monster/cookie-monster-bof.c:74:85: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                                     ^~~~~~~~
cookie-monster/cookie-monster-bof.c:75:5: error: unknown type name ‘PFN_PathAppendA’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:5: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:35: error: ‘PFN_PathAppendA’ undeclared (first use in this function); did you mean ‘PathAppend’?
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                   ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:35: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                   ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:51: error: expected ‘,’ or ‘;’ before ‘Resolver’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                                   ^~~~~~~~
cookie-monster/cookie-monster-bof.c:75:51: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                                   ^~~~~~~~
cookie-monster/cookie-monster-bof.c:440:5: error: called object ‘SHGetFolderPath’ is not a function or function pointer
  440 |     SHGetFolderPath(NULL, CSIDL_APPDATA, NULL, 0, appdata);
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:45: note: declared here
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                             ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:45: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                             ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:442:5: error: called object ‘PathAppend’ is not a function or function pointer
  442 |     PathAppend(appdata, "\\Mozilla\\Firefox\\Profiles");
      |     ^~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:21: note: declared here
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                     ^~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:21: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                     ^~~~~~~~~~
cookie-monster/cookie-monster-bof.c:443:5: error: called object ‘PathAppend’ is not a function or function pointer
  443 |     PathAppend(appdata, file);
      |     ^~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:21: note: declared here
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                     ^~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:21: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                     ^~~~~~~~~~
cookie-monster/cookie-monster-bof.c: In function ‘GetFirefoxInfo’:
cookie-monster/cookie-monster-bof.c:74:24: error: unknown type name ‘PFN_SHGetFolderPathA’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                        ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:24: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                        ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: error: ‘PFN_SHGetFolderPathA’ undeclared (first use in this function); did you mean ‘SHGetFolderPath’?
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:85: error: expected ‘,’ or ‘;’ before ‘Resolver’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                                     ^~~~~~~~
cookie-monster/cookie-monster-bof.c:74:85: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                                     ^~~~~~~~
cookie-monster/cookie-monster-bof.c:75:5: error: unknown type name ‘PFN_PathAppendA’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:5: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:35: error: ‘PFN_PathAppendA’ undeclared (first use in this function); did you mean ‘PathAppend’?
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                   ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:35: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                   ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:51: error: expected ‘,’ or ‘;’ before ‘Resolver’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                                   ^~~~~~~~
cookie-monster/cookie-monster-bof.c:75:51: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                                   ^~~~~~~~
cookie-monster/cookie-monster-bof.c:456:5: error: called object ‘SHGetFolderPath’ is not a function or function pointer
  456 |     SHGetFolderPath(NULL, CSIDL_APPDATA, NULL, 0, appdata);
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:45: note: declared here
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                             ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:45: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                             ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:457:5: error: called object ‘PathAppend’ is not a function or function pointer
  457 |     PathAppend(appdata, "\\Mozilla\\Firefox\\profiles.ini");
      |     ^~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:21: note: declared here
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                     ^~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:21: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                     ^~~~~~~~~~
cookie-monster/cookie-monster-bof.c: In function ‘GetBrowserFile’:
cookie-monster/cookie-monster-bof.c:74:24: error: unknown type name ‘PFN_SHGetFolderPathA’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                        ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:24: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                        ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: error: ‘PFN_SHGetFolderPathA’ undeclared (first use in this function); did you mean ‘SHGetFolderPath’?
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:85: error: expected ‘,’ or ‘;’ before ‘Resolver’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                                     ^~~~~~~~
cookie-monster/cookie-monster-bof.c:74:85: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                                     ^~~~~~~~
cookie-monster/cookie-monster-bof.c:75:5: error: unknown type name ‘PFN_PathAppendA’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:5: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:35: error: ‘PFN_PathAppendA’ undeclared (first use in this function); did you mean ‘PathAppend’?
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                   ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:35: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                   ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:51: error: expected ‘,’ or ‘;’ before ‘Resolver’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                                   ^~~~~~~~
cookie-monster/cookie-monster-bof.c:75:51: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                                   ^~~~~~~~
cookie-monster/cookie-monster-bof.c: In function ‘AppBoundDecryptor’:
cookie-monster/cookie-monster-bof.c:74:24: error: unknown type name ‘PFN_SHGetFolderPathA’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                        ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:24: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                        ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: error: ‘PFN_SHGetFolderPathA’ undeclared (first use in this function); did you mean ‘SHGetFolderPath’?
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:64: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                ^~~~~~~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:74:85: error: expected ‘,’ or ‘;’ before ‘Resolver’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                                     ^~~~~~~~
cookie-monster/cookie-monster-bof.c:74:85: note: in definition of macro ‘IMPORT_RESOLVE’
   74 | #define IMPORT_RESOLVE PFN_SHGetFolderPathA SHGetFolderPath = (PFN_SHGetFolderPathA)Resolver("shell32", "SHGetFolderPathA"); \
      |                                                                                     ^~~~~~~~
cookie-monster/cookie-monster-bof.c:75:5: error: unknown type name ‘PFN_PathAppendA’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:5: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |     ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:35: error: ‘PFN_PathAppendA’ undeclared (first use in this function); did you mean ‘PathAppend’?
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                   ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:35: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                   ^~~~~~~~~~~~~~~
cookie-monster/cookie-monster-bof.c:75:51: error: expected ‘,’ or ‘;’ before ‘Resolver’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                                   ^~~~~~~~
cookie-monster/cookie-monster-bof.c:75:51: note: in definition of macro ‘IMPORT_RESOLVE’
   75 |     PFN_PathAppendA PathAppend = (PFN_PathAppendA)Resolver("shlwapi", "PathAppendA"); \
      |                                                   ^~~~~~~~
[!] cookie-monster build failed
```

Adding the missing typede to `Extension-Kit/Creds-BOF/cookie-monster/cookie-monster-bof.c` will fix the error

```diff
#include <windows.h>
#include <stdint.h>
#include <ctype.h>
#include <stdio.h>
#include <tlhelp32.h>
#include "cookie-monster-bof.h"
#include "adaptix.h"

+ // Add missing typedef
+ typedef HRESULT (WINAPI *PFN_SHGetFolderPathA)(HWND hwndOwner, int nFolder, HANDLE hToken, DWORD dwFlags, LPSTR pszPath);
+ typedef BOOL (WINAPI *PFN_PathAppendA)(LPSTR pszPath, LPCSTR pMore);

// Function declarations
// ...
```