### PR TITLE
WinRM: background execution via WMI with status output

### DIFF
--- a/LateralMovement-BOF/README.md
+++ b/LateralMovement-BOF/README.md
@@ -44,8 +44,13 @@ Choose services that:
 Use WinRM to execute commands on other systems
 
 ```
-invoke winrm <computer> <command>
+invoke winrm <computer> <command> [-t timeout_ms] [-b]
 ```
+
+* `-t` - Timeout in milliseconds to wait for output (0 = infinite)
+* `-b` - Detach command (cmd.exe /c start /b), no output capture
+
+Note: when using flags and a command with spaces, quote the command and place flags after it.
 
 
 

--- a/LateralMovement-BOF/lateral.axs
+++ b/LateralMovement-BOF/lateral.axs
@@ -67,14 +67,18 @@ cmd_jump.addSubCommands([_cmd_jump_psexec, _cmd_jump_scshell]);
 
 
 
-var _cmd_invoke_winrm = ax.create_command("winrm", "Use WinRM to execute commands on other systems", "invoke winrm 192.168.0.1 whoami /all");
+var _cmd_invoke_winrm = ax.create_command("winrm", "Use WinRM to execute commands on other systems", "invoke winrm 192.168.0.1 \"whoami /all\" -t 60000");
 _cmd_invoke_winrm.addArgString("target", true);
 _cmd_invoke_winrm.addArgString("cmd", true);
+_cmd_invoke_winrm.addArgFlagInt("-t", "timeout", "Timeout in milliseconds to wait for output (0 = infinite)", 0);
+_cmd_invoke_winrm.addArgBool("-b", "background", "Detach command (cmd.exe /c start /b), no output");
 _cmd_invoke_winrm.setPreHook(function (id, cmdline, parsed_json, ...parsed_lines) {
     let target = parsed_json["target"];
     let cmd = parsed_json["cmd"];
+    let timeout = parsed_json["timeout"];
+    let background = parsed_json["-b"] ? 1 : 0;
 
-    let bof_params = ax.bof_pack("wstr,wstr", [target, cmd]);
+    let bof_params = ax.bof_pack("wstr,wstr,int,int", [target, cmd, timeout, background]);
     let bof_path = ax.script_dir() + "_bin/winrm." + ax.arch(id) + ".o";
     let message = `Task: Invoke to ${target} via WinRM`;
 


### PR DESCRIPTION
Rework invoke WinRm to run detached process using -b argument to execute in background through WMI a process.

example :
invoke winrm SRV01 C:\Windows\temp\smb-pivot.exe -b