### PR TITLE
Fix jump psexec random service name/description bug

### DIFF
--- a/LateralMovement-BOF/lateral.axs
+++ b/LateralMovement-BOF/lateral.axs
@@ -21,8 +21,8 @@ _cmd_jump_psexec.setPreHook(function (id, cmdline, parsed_json, ...parsed_lines)
     let svc_description = parsed_json["svc_description"];
 
     if (binary_name == "random")  binary_name = ax.random_string(8, "alphabetic") + ".exe";
-    if (svc_name.length == "random")  svc_name = ax.random_string(10, "alphabetic");
-    if (svc_description.length == "random")  svc_description = ax.random_string(16, "alphabetic");
+    if (svc_name == "random")  svc_name = ax.random_string(10, "alphabetic");
+    if (svc_description == "random")  svc_description = ax.random_string(16, "alphabetic");
 
     let bof_params = ax.bof_pack("cstr,bytes,cstr,cstr,cstr,cstr,cstr", [target, binary_content, binary_name, share, svc_path, svc_name, svc_description]);
     let bof_path = ax.script_dir() + "_bin/psexec." + ax.arch(id) + ".o";


### PR DESCRIPTION
When the operator does not specify a service name and/or service description, the `jump psexec` BOF is supposed to generate and use a random service name and/or service description (technically, display name).

Currently, the `lateral.axs` script compares the svc_name and svc_description length, not the value, to the "random" string, so the condition is never true and the values never get randomized. This results in the service name and service display name being literally "random" every time that `jump psexec` is used without specifying the service name which generates a 1078 error the next time the BOF is ran since the "random" service name will already exist.

This pull request is for updating the if statements to compare the values of svc_name and svc_description, rather than the lengths.