### PR TITLE
fix: cross-platform compilation fixes for Arch GCC 15.2 / MinGW toolchains

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,71 @@
+name: C/C++ Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - ubuntu:latest
+          - kalilinux/kali-rolling
+          - archlinux:latest
+
+    container:
+      image: ${{ matrix.os-image }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Build Dependencies
+        run: |
+          if command -v apt-get &> /dev/null; then
+            apt-get update
+            apt-get install -y \
+              build-essential \
+              g++-mingw-w64-x86-64-posix \
+              gcc-mingw-w64-x86-64-posix \
+              mingw-w64-tools \
+              gcc-mingw-w64-i686 \
+              g++-mingw-w64-i686 \
+              python3
+          elif command -v pacman &> /dev/null; then
+            pacman -Sy --noconfirm base-devel mingw-w64-gcc
+          fi
+
+      - name: Run Make
+        run: make
+
+
+  build-macos:
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Extra Dependencies
+        run: |
+          brew update || true
+          brew install mingw-w64
+
+      - name: Run Make
+        run: make
+
+
+  docker-verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Verify Docker Build
+        run: make docker-build

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ Creds-BOF/nanodump/dist/
 .DS_Store
 **/.DS_Store
 
+.planning
+.claude
+
 *.o
 *.swp
 *.exe

--- a/Creds-BOF/cookie-monster/cookie-monster-bof.c
+++ b/Creds-BOF/cookie-monster/cookie-monster-bof.c
@@ -1,4 +1,5 @@
 #include <windows.h>
+#include <objbase.h>
 #include <stdint.h> 
 #include <ctype.h>
 #include <stdio.h>

--- a/Creds-BOF/nanodump/Makefile
+++ b/Creds-BOF/nanodump/Makefile
@@ -17,6 +17,12 @@ nanodump:
 	@$(CC_x86) -c source/entry.c -o dist/$(BOFNAME).x86.o $(OPTIONS) -DNANO -DBOF
 	@$(STRIP_x86) --strip-unneeded dist/$(BOFNAME).x86.o && echo '[+] nanodump x86' || echo '[!] nanodump x86'
 
+	@$(CC_x64) source/spoof_callstack.c source/hw_breakpoint.c source/shtinkering.c source/dinvoke.c source/utils.c source/handle.c source/impersonate.c source/modules.c source/syscalls.c source/token_priv.c source/malseclogon.c source/nanodump.c source/werfault.c source/entry.c -o dist/$(BOFNAME).x64.exe $(OPTIONS) -DNANO -DEXE
+	@$(STRIP_x64) --strip-all dist/$(BOFNAME).x64.exe && echo '[+] nanodump exe x64' || echo '[!] nanodump exe x64'
+
+	@$(CC_x86) source/spoof_callstack.c source/hw_breakpoint.c source/shtinkering.c source/dinvoke.c source/utils.c source/handle.c source/impersonate.c source/modules.c source/syscalls.c source/token_priv.c source/malseclogon.c source/nanodump.c source/werfault.c source/entry.c -o dist/$(BOFNAME).x86.exe $(OPTIONS) -DNANO -DEXE
+	@$(STRIP_x86) --strip-all dist/$(BOFNAME).x86.exe && echo '[+] nanodump exe x86' || echo '[!] nanodump exe x86'
+
 	@$(GCC) source/bin2c.c -o dist/bin2c -Os
 
 	@$(CC_x64) source/utils.c source/handle.c source/modules.c source/syscalls.c source/token_priv.c source/nanodump.c source/dinvoke.c source/pipe.c source/entry.c -o dist/$(BOFNAME)_ssp.x64.dll $(OPTIONS) $(SSP_OPTIONS) -DNANO -DSSP -DDDL -shared

--- a/Creds-BOF/nanodump/Makefile
+++ b/Creds-BOF/nanodump/Makefile
@@ -11,19 +11,13 @@ SSP_OPTIONS := -DPASS_PARAMS_VIA_NAMED_PIPES=1
 nanodump:
 	@(mkdir dist 2>/dev/null) && echo 'creating dist' || echo 'dist exists'
 
-	@$(CC_x64) source/spoof_callstack.c source/hw_breakpoint.c source/shtinkering.c source/dinvoke.c source/utils.c source/handle.c source/impersonate.c source/modules.c source/syscalls.c source/token_priv.c source/malseclogon.c source/nanodump.c source/werfault.c source/entry.c -o dist/$(BOFNAME).x64.exe $(OPTIONS) -DNANO -DEXE
-	@$(STRIP_x64) --strip-all dist/$(BOFNAME).x64.exe
-
-	@$(CC_x86) source/spoof_callstack.c source/hw_breakpoint.c source/shtinkering.c source/dinvoke.c source/utils.c source/handle.c source/impersonate.c source/modules.c source/syscalls.c source/token_priv.c source/malseclogon.c source/nanodump.c source/werfault.c source/entry.c -o dist/$(BOFNAME).x86.exe $(OPTIONS) -DNANO -DEXE
-	@$(STRIP_x86) --strip-all dist/$(BOFNAME).x86.exe
-
 	@$(CC_x64) -c source/entry.c -o dist/$(BOFNAME).x64.o $(OPTIONS) -DNANO -DBOF
 	@$(STRIP_x64) --strip-unneeded dist/$(BOFNAME).x64.o && echo '[+] nanodump x64' || echo '[!] nanodump x64'
 
 	@$(CC_x86) -c source/entry.c -o dist/$(BOFNAME).x86.o $(OPTIONS) -DNANO -DBOF
 	@$(STRIP_x86) --strip-unneeded dist/$(BOFNAME).x86.o && echo '[+] nanodump x86' || echo '[!] nanodump x86'
 
-	@$(GCC) source/bin2c.c -o dist/bin2c -static -s -Os
+	@$(GCC) source/bin2c.c -o dist/bin2c -Os
 
 	@$(CC_x64) source/utils.c source/handle.c source/modules.c source/syscalls.c source/token_priv.c source/nanodump.c source/dinvoke.c source/pipe.c source/entry.c -o dist/$(BOFNAME)_ssp.x64.dll $(OPTIONS) $(SSP_OPTIONS) -DNANO -DSSP -DDDL -shared
 	@$(STRIP_x64) --strip-all dist/$(BOFNAME)_ssp.x64.dll && echo '[+] nanodump_ssp Dll x64' || echo '[!] nanodump_ssp Dll x64'
@@ -75,8 +69,7 @@ nanodump:
 	@$(CC_x64) -c source/ppl/ppl.c -o dist/$(BOFNAME)_ppl_medic.x64.o $(OPTIONS) $(PPL_MEDIC_OPTIONS) -DBOF -DPPL_MEDIC
 	@$(STRIP_x64) --strip-unneeded dist/$(BOFNAME)_ppl_medic.x64.o && echo '[+] nanodump_ppl_medic x64' || echo '[!] nanodump_ppl_medic x64'
 
-	@$(GCC) source/restore_signature.c -o scripts/restore_signature -static -s -Os
-	@$(STRIP_x64) --strip-all scripts/restore_signature
+	@$(GCC) source/restore_signature.c -o scripts/restore_signature -Os
 
 clean:
 	@rm -f dist/*

--- a/Creds-BOF/nanodump/include/ppl/ppl_medic.h
+++ b/Creds-BOF/nanodump/include/ppl/ppl_medic.h
@@ -4,6 +4,14 @@
 #include "token_priv.h"
 #include "dinvoke.h"
 #include "handle.h"
+#ifdef PPL_MEDIC
+#ifndef CINTERFACE
+#define CINTERFACE
+#endif
+#include <objbase.h>
+#include <unknwn.h>
+#include <oaidl.h>
+#endif
 
 #define TH32CS_SNAPTHREAD 0x00000004
 
@@ -27,8 +35,10 @@ typedef ULONGLONG(WINAPI* GetTickCount64_t) ();
 typedef SC_HANDLE(WINAPI* OpenSCManagerW_t)(LPCWSTR lpMachineName, LPCWSTR lpDatabaseName, DWORD dwDesiredAccess);
 typedef SC_HANDLE(WINAPI* OpenServiceW_t)(SC_HANDLE hSCManager, LPCWSTR lpServiceName, DWORD dwDesiredAccess);
 typedef BOOL(WINAPI* CloseServiceHandle_t)(SC_HANDLE hSCObject);
+#ifdef PPL_MEDIC
 typedef HRESULT(WINAPI* LoadTypeLib_t)(LPCOLESTR szFile, ITypeLib **pptlib);
 typedef HRESULT(WINAPI* CreateTypeLib2_t)(SYSKIND syskind, LPCOLESTR szFile, ICreateTypeLib2 **ppctlib);
+#endif
 typedef BSTR(WINAPI* SysAllocString_t)(const OLECHAR *psz);
 typedef VOID(WINAPI* SysFreeString_t)(BSTR bstrString);
 typedef HANDLE(WINAPI* CreateToolhelp32Snapshot_t)(DWORD dwFlags, DWORD th32ProcessID);

--- a/Creds-BOF/nanodump/include/ppl/ppl_utils.h
+++ b/Creds-BOF/nanodump/include/ppl/ppl_utils.h
@@ -2,6 +2,13 @@
 
 #include <windows.h>
 #include <winternl.h>
+#ifdef PPL_MEDIC
+#ifndef CINTERFACE
+#define CINTERFACE
+#endif
+#include <objbase.h>
+#include <unknwn.h>
+#endif
 
 #include "utils.h"
 #include "dinvoke.h"
@@ -131,8 +138,10 @@ BOOL get_registry_string_value(
     IN LPCWSTR ValueName,
     OUT LPWSTR* ValueData);
 
+#ifdef PPL_MEDIC
 VOID safe_release(
     IN IUnknown** Interface);
+#endif
 
 BOOL generate_temp_path(
     OUT LPWSTR* Buffer);

--- a/Creds-BOF/nanodump/source/dinvoke.c
+++ b/Creds-BOF/nanodump/source/dinvoke.c
@@ -1,4 +1,7 @@
 #include "dinvoke.h"
+#ifndef BOF
+#include <stdlib.h>
+#endif
 
 // used by spoof_callstack
 PVOID find_dll_by_pointer(

--- a/Creds-BOF/nanodump/source/entry.c
+++ b/Creds-BOF/nanodump/source/entry.c
@@ -1,4 +1,7 @@
 #include "entry.h"
+#ifndef BOF
+#include <stdlib.h>
+#endif
 
 #ifdef BOF
  #include "nanodump.c"

--- a/Creds-BOF/nanodump/source/ppl/ppl_dump.c
+++ b/Creds-BOF/nanodump/source/ppl/ppl_dump.c
@@ -1,4 +1,7 @@
 #include "ppl/ppl_dump.h"
+#ifndef BOF
+#include <stdlib.h>
+#endif
 
 BOOL run_ppl_dump_exploit(
     IN unsigned char nanodump_ppl_dump_dll[],

--- a/Creds-BOF/nanodump/source/ppl/ppl_utils.c
+++ b/Creds-BOF/nanodump/source/ppl/ppl_utils.c
@@ -623,6 +623,7 @@ VOID safe_free(
     }
 }
 
+#ifdef PPL_MEDIC
 VOID safe_release(
     IN IUnknown** Interface)
 {
@@ -632,6 +633,7 @@ VOID safe_release(
         *Interface = NULL;
     }
 }
+#endif
 
 BOOL get_type_lib_reg_value_path(
     OUT LPWSTR* TypeLibRegValuePath)

--- a/Creds-BOF/nanodump/source/ssp/ssp.c
+++ b/Creds-BOF/nanodump/source/ssp/ssp.c
@@ -1,5 +1,8 @@
 #include "ssp/ssp.h"
 #include "ssp/ssp_utils.h"
+#ifndef BOF
+#include <stdlib.h>
+#endif
 
 DWORD WINAPI load_ssp(LPVOID Parameter)
 {

--- a/Creds-BOF/nanodump/source/ssp/ssp_utils.c
+++ b/Creds-BOF/nanodump/source/ssp/ssp_utils.c
@@ -1,6 +1,9 @@
 #include "ssp/ssp_utils.h"
 #include "utils.h"
 #include "pipe.h"
+#ifndef BOF
+#include <stdlib.h>
+#endif
 
 BOOL generate_random_dll_path(
     OUT LPSTR* random_path)

--- a/Creds-BOF/nanodump/source/utils.c
+++ b/Creds-BOF/nanodump/source/utils.c
@@ -3,6 +3,9 @@
 #include "dinvoke.h"
 #include "syscalls.h"
 #include "adaptix.h"
+#ifndef BOF
+#include <stdlib.h>
+#endif
 
 #ifndef SSP
 

--- a/Elevation-BOF/potato-dcom/DCOMPotato.cpp
+++ b/Elevation-BOF/potato-dcom/DCOMPotato.cpp
@@ -1,5 +1,6 @@
 #include <windows.h>
 #include <stdio.h>
+#include <objbase.h>
 #include <ocidl.h>
 #include <lm.h>
 #include "bofdefs.h"

--- a/Elevation-BOF/uac_sspi/SspiUacBypassBOF.cpp
+++ b/Elevation-BOF/uac_sspi/SspiUacBypassBOF.cpp
@@ -2,6 +2,7 @@
 #define SECURITY_WIN32
 
 #include <windows.h>
+#include <objbase.h>
 #include <stdio.h>
 #include <security.h>
 

--- a/Execution-BOF/No-Consolation/include/utils.h
+++ b/Execution-BOF/No-Consolation/include/utils.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <limits.h>
 
 #define ARGUMENT_PRESENT(ArgumentPointer) \
   ((CHAR*)((ULONG_PTR)(ArgumentPointer)) != (CHAR*)NULL)

--- a/Postex-BOF/ScreenshotBOF/entry.c
+++ b/Postex-BOF/ScreenshotBOF/entry.c
@@ -1,4 +1,5 @@
 #include <windows.h>
+#include <objbase.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <gdiplus.h>

--- a/Postex-BOF/firewallrule/addfirewallrule.c
+++ b/Postex-BOF/firewallrule/addfirewallrule.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <windows.h>
+#include <objbase.h>
 #include <netfw.h>
 #include "firewallrule.h"
 #include "beacon.h"

--- a/SAL-BOF/arp/arp.c
+++ b/SAL-BOF/arp/arp.c
@@ -1,4 +1,5 @@
 #include <windows.h>
+#include <objbase.h>
 #include <iphlpapi.h>
 #include "bofdefs.h"
 #include "base.c"

--- a/SAL-BOF/ipconfig/ipconfig.c
+++ b/SAL-BOF/ipconfig/ipconfig.c
@@ -1,4 +1,5 @@
 #include <windows.h>
+#include <objbase.h>
 #include <iphlpapi.h>
 #include "bofdefs.h"
 #include "base.c"

--- a/SAL-BOF/netstat/netstat.c
+++ b/SAL-BOF/netstat/netstat.c
@@ -1,4 +1,5 @@
 #include <windows.h>
+#include <objbase.h>
 #include <winbase.h>
 #include <iphlpapi.h>
 #include "bofdefs.h"

--- a/SAL-BOF/routeprint/routeprint.c
+++ b/SAL-BOF/routeprint/routeprint.c
@@ -1,4 +1,5 @@
 #include <windows.h>
+#include <objbase.h>
 #include <iphlpapi.h>
 #include "bofdefs.h"
 #include "base.c"

--- a/SAR-BOF/EdrEnum-BOF/bofdefs.h
+++ b/SAR-BOF/EdrEnum-BOF/bofdefs.h
@@ -1,5 +1,6 @@
 #pragma once
 #pragma intrinsic(memcmp, memcpy,strcpy,strcmp,_stricmp,strlen)
+#include <objbase.h>
 #include <windows.h>
 #include <process.h>
 #include <winternl.h>

--- a/_include/bofdefs.h
+++ b/_include/bofdefs.h
@@ -1,5 +1,6 @@
 #pragma once
 #pragma intrinsic(memcmp, memcpy,strcpy,strcmp,_stricmp,strlen)
+#include <objbase.h>
 #include <windows.h>
 #include <process.h>
 #include <winternl.h>


### PR DESCRIPTION
Fixes compilation errors on Arch Linux GCC 15.2.0 with MinGW cross-compilers and ensures the project builds cleanly across Ubuntu, Kali, Arch, and macOS. Also adds a CI workflow and Dockerized build for ongoing cross-platform testing.

## Source fixes

- `_include/bofdefs.h`, `SAR-BOF/EdrEnum-BOF/bofdefs.h`: add `<objbase.h>` to fix `BEGIN_INTERFACE`/`IUnknown`/`COINIT_*`/`LPSTREAM` errors on newer GCC
- `Creds-BOF/cookie-monster/cookie-monster-bof.c`: add `<objbase.h>`
- `Elevation-BOF/potato-dcom/DCOMPotato.cpp`, `Elevation-BOF/uac_sspi/SspiUacBypassBOF.cpp`, `Postex-BOF/ScreenshotBOF/entry.c`, `Postex-BOF/firewallrule/addfirewallrule.c`: add `<objbase.h>`
- `SAL-BOF/arp/arp.c`, `ipconfig/ipconfig.c`, `netstat/netstat.c`, `routeprint/routeprint.c`: add `<objbase.h>`
- `Execution-BOF/No-Consolation/include/utils.h`: add `<limits.h>` for `LONG_MAX` (removed from implicit includes in GCC 15)
- `Creds-BOF/nanodump/`: add missing COM/WinAPI headers; update Makefile for MinGW toolchain compatibility and remove unnecessary .exe builds 

## CI

- `.github/workflows/build.yml`: three jobs — `build-linux` matrix (ubuntu:latest, kalilinux/kali-rolling, archlinux:latest), `build-macos` (macos-14), and `docker-verify` (bare ubuntu-latest, runs `make docker-build`)

## Gitignore

- Add `.planning` and `.claude` to `.gitignore`

Closes: https://github.com/Adaptix-Framework/Extension-Kit/issues/129