### PR TITLE
Replace add_agent.sh with more robust Python implementation

### DIFF
--- a/add_agent.py
+++ b/add_agent.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+from pathlib import Path
+
+# Supported AXScript calls that contain an agents array.
+CALLS = [
+    "ax.register_commands_group",
+    "menu.add_session_access",
+    "menu.add_processbrowser",
+]
+
+# Regex explanation:
+#
+# Match calls like:
+#   ax.register_commands_group(group, ["beacon"], ...)
+#   menu.add_session_access(action, ["beacon"], ...)
+#
+# Captures:
+#   prefix -> function call + first argument + comma
+#   agents -> ["beacon", "gopher"]
+CALL_RE = re.compile(
+    r'(?P<prefix>(?:'
+    + "|".join(re.escape(call) for call in CALLS)
+    + r')\s*\([^,\n]+,\s*)'
+    r'(?P<agents>\[[^\]]*\])'
+)
+
+
+def parse_agents(array_text: str) -> list[str]:
+    """
+    Extract:
+        ["beacon", "gopher"]
+
+    Into:
+        ["beacon", "gopher"]
+    """
+    return re.findall(r'"([^"]+)"', array_text)
+
+
+def format_agents(agents: list[str]) -> str:
+    """
+    Convert Python list into AXScript array syntax.
+    """
+    return "[" + ", ".join(f'"{agent}"' for agent in agents) + "]"
+
+
+def update_content(content: str, agent_name: str, delete_mode: bool) -> tuple[str, bool]:
+    """
+    Add or remove agent_name in supported AXScript calls.
+    """
+    changed = False
+
+    def replace(match: re.Match) -> str:
+        nonlocal changed
+
+        agents = parse_agents(match.group("agents"))
+
+        if delete_mode:
+            if agent_name not in agents:
+                return match.group(0)
+
+            agents = [a for a in agents if a != agent_name]
+            changed = True
+
+        else:
+            if agent_name in agents:
+                return match.group(0)
+
+            agents.append(agent_name)
+            changed = True
+
+        return match.group("prefix") + format_agents(agents)
+
+    return CALL_RE.sub(replace, content), changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Add or remove custom agents from Extension-Kit AXScript files."
+    )
+
+    parser.add_argument(
+        "agent_name",
+        help="Agent name (example: CrystalAgent)"
+    )
+
+    parser.add_argument(
+        "--delete",
+        action="store_true",
+        help="Remove the agent instead of adding it"
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show files that would be modified without writing changes"
+    )
+
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parent
+    updated = 0
+
+    for path in sorted(root.rglob("*.axs")):
+        content = path.read_text(encoding="utf-8")
+
+        new_content, changed = update_content(
+            content,
+            args.agent_name,
+            args.delete
+        )
+
+        if not changed:
+            continue
+
+        updated += 1
+        rel = path.relative_to(root)
+
+        if args.dry_run:
+            print(f"[DRY-RUN] Would update: {rel}")
+        else:
+            path.write_text(new_content, encoding="utf-8")
+            print(f"[+] Updated: {rel}")
+
+    action = "removed from" if args.delete else "added to"
+
+    print(f"--- Complete: {args.agent_name} {action} {updated} file(s) ---")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/add_agent.sh
+++ b/add_agent.sh
@@ -1,23 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [ -z "$1" ]; then
-    echo "Use: $0 <agent_name>"
-    echo "Example: $0 kharon"
-    exit 1
-fi
-
-AGENT_NAME="$1"
-
-find . -type f -name "*.axs" | while read -r file; do
-    if grep -q 'register_commands_group' "$file" && grep -q '"beacon", "gopher"' "$file"; then
-        if ! grep -q "$AGENT_NAME" "$file"; then
-            echo "[+] Update file: $file"
-
-            sed -i 's/\["beacon", "gopher"\]/["beacon", "gopher", "'"$AGENT_NAME"'"]/g' "$file"
-        else
-            echo "[!] Agent $AGENT_NAME already exists in $file"
-        fi
-    fi
-done
-
-echo "--- Complete ---"
+python3 add_agent.py "$@"


### PR DESCRIPTION
This PR improves the custom agent registration workflow in the Extension Kit.

The current bash script relies on fixed string replacements and may miss some AXScript registrations depending on file structure or already registered agents.

Changes introduced:

- Add a Python-based registration script
- Automatically scans all .axs files recursively
- Updates supported registrations such as:
  - ax.register_commands_group(...)
  - menu.add_session_access(...)
  - menu.add_processbrowser(...)
- Prevents duplicate agent entries
- Adds --delete support to remove an agent
- Adds --dry-run mode to preview changes

This makes onboarding custom agents more reliable and easier to maintain.