### PR TITLE
fix(nanodump): remove -static flag for macOS compatibility

### DIFF
--- a/Creds-BOF/nanodump/Makefile
+++ b/Creds-BOF/nanodump/Makefile
@@ -23,7 +23,7 @@ nanodump:
 	@$(CC_x86) -c source/entry.c -o dist/$(BOFNAME).x86.o $(OPTIONS) -DNANO -DBOF
 	@$(STRIP_x86) --strip-unneeded dist/$(BOFNAME).x86.o && echo '[+] nanodump x86' || echo '[!] nanodump x86'
 
-	@$(GCC) source/bin2c.c -o dist/bin2c -static -s -Os
+	@$(GCC) source/bin2c.c -o dist/bin2c -s -Os
 
 	@$(CC_x64) source/utils.c source/handle.c source/modules.c source/syscalls.c source/token_priv.c source/nanodump.c source/dinvoke.c source/pipe.c source/entry.c -o dist/$(BOFNAME)_ssp.x64.dll $(OPTIONS) $(SSP_OPTIONS) -DNANO -DSSP -DDDL -shared
 	@$(STRIP_x64) --strip-all dist/$(BOFNAME)_ssp.x64.dll && echo '[+] nanodump_ssp Dll x64' || echo '[!] nanodump_ssp Dll x64'
@@ -75,8 +75,7 @@ nanodump:
 	@$(CC_x64) -c source/ppl/ppl.c -o dist/$(BOFNAME)_ppl_medic.x64.o $(OPTIONS) $(PPL_MEDIC_OPTIONS) -DBOF -DPPL_MEDIC
 	@$(STRIP_x64) --strip-unneeded dist/$(BOFNAME)_ppl_medic.x64.o && echo '[+] nanodump_ppl_medic x64' || echo '[!] nanodump_ppl_medic x64'
 
-	@$(GCC) source/restore_signature.c -o scripts/restore_signature -static -s -Os
-	@$(STRIP_x64) --strip-all scripts/restore_signature
+	@$(GCC) source/restore_signature.c -o scripts/restore_signature -s -Os
 
 clean:
 	@rm -f dist/*


### PR DESCRIPTION
## Summary

Fixes compilation error on macOS by removing `-static` linker flag from nanodump Makefile.

## Problem

macOS does not support static linking of system libraries, which caused the following linker error:
```
ld: library 'crt0.o' not found
clang: error: linker command failed with exit code 1
```

## Changes

- Remove `-static` flag from `bin2c` compilation (line 26)
- Remove `-static` flag from `restore_signature` compilation (line 78)
- Remove incorrect mingw strip command for native binary (line 79)

## Testing

Successfully compiled all 131 BOF modules on macOS 14.5 with:
- mingw-w64 GCC 15.2.0
- Apple clang version 15.0.0

## Compatibility

This change maintains compatibility with Linux builds while enabling macOS compilation.