### PR TITLE
fix(nanodump): make host-tool build work on macOS

### DIFF
--- a/Creds-BOF/nanodump/Makefile
+++ b/Creds-BOF/nanodump/Makefile
@@ -8,6 +8,16 @@ OPTIONS := -masm=intel -Wimplicit-function-declaration -Wall -I include -Wl,--dy
 PPL_MEDIC_OPTIONS := -Wno-trigraphs -DPASS_PARAMS_VIA_NAMED_PIPES=1
 SSP_OPTIONS := -DPASS_PARAMS_VIA_NAMED_PIPES=1
 
+# macOS' gcc is clang and does not support static linking (no crt0.o) or -s.
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	HOST_FLAGS :=
+	HOST_STRIP := strip
+else
+	HOST_FLAGS := -static -s
+	HOST_STRIP := $(STRIP_x64)
+endif
+
 nanodump:
 	@(mkdir dist 2>/dev/null) && echo 'creating dist' || echo 'dist exists'
 
@@ -23,7 +33,7 @@ nanodump:
 	@$(CC_x86) -c source/entry.c -o dist/$(BOFNAME).x86.o $(OPTIONS) -DNANO -DBOF
 	@$(STRIP_x86) --strip-unneeded dist/$(BOFNAME).x86.o && echo '[+] nanodump x86' || echo '[!] nanodump x86'
 
-	@$(GCC) source/bin2c.c -o dist/bin2c -static -s -Os
+	@$(GCC) source/bin2c.c -o dist/bin2c $(HOST_FLAGS) -Os
 
 	@$(CC_x64) source/utils.c source/handle.c source/modules.c source/syscalls.c source/token_priv.c source/nanodump.c source/dinvoke.c source/pipe.c source/entry.c -o dist/$(BOFNAME)_ssp.x64.dll $(OPTIONS) $(SSP_OPTIONS) -DNANO -DSSP -DDDL -shared
 	@$(STRIP_x64) --strip-all dist/$(BOFNAME)_ssp.x64.dll && echo '[+] nanodump_ssp Dll x64' || echo '[!] nanodump_ssp Dll x64'
@@ -75,8 +85,8 @@ nanodump:
 	@$(CC_x64) -c source/ppl/ppl.c -o dist/$(BOFNAME)_ppl_medic.x64.o $(OPTIONS) $(PPL_MEDIC_OPTIONS) -DBOF -DPPL_MEDIC
 	@$(STRIP_x64) --strip-unneeded dist/$(BOFNAME)_ppl_medic.x64.o && echo '[+] nanodump_ppl_medic x64' || echo '[!] nanodump_ppl_medic x64'
 
-	@$(GCC) source/restore_signature.c -o scripts/restore_signature -static -s -Os
-	@$(STRIP_x64) --strip-all scripts/restore_signature
+	@$(GCC) source/restore_signature.c -o scripts/restore_signature $(HOST_FLAGS) -Os
+	@$(HOST_STRIP) scripts/restore_signature
 
 clean:
 	@rm -f dist/*


### PR DESCRIPTION
## Problem

Building `Creds-BOF` on macOS fails in the nanodump Makefile:

```
ld: warning: -s is obsolete
ld: library 'crt0.o' not found
clang: error: linker command failed with exit code 1
```

and then:

```
x86_64-w64-mingw32-strip: scripts/restore_signature: file format not recognized
```

The cross-compiled BOF artifacts (mingw `.o`/`.exe`/`.dll`) build fine. The failures are only in the **host**-compiled helper tools (`bin2c`, `restore_signature`):

- On macOS `gcc` is Apple clang, which does not support `-static` (there is no `crt0.o` / static libc) nor the obsolete `-s` linker flag.
- `restore_signature` is then stripped with the **mingw** strip, which only understands Windows PE — not the native Mach-O binary.

## Fix

Detect the host OS in `Creds-BOF/nanodump/Makefile`:

- Drop `-static -s` from the host `gcc` invocations on Darwin.
- Use the host `strip` (not the mingw strip) for the native `restore_signature` helper.

Linux behavior is unchanged (`-static -s` and mingw strip are kept).